### PR TITLE
texture rewrite

### DIFF
--- a/crates/demo/src/main.rs
+++ b/crates/demo/src/main.rs
@@ -78,7 +78,7 @@ async fn run() {
     }
 
     // Preload a texture for the examples to use.
-    let monkey = yak.add_texture(load_texture(MONKEY_PNG));
+    let monkey = graphics.add_texture(load_texture(MONKEY_PNG));
 
     // Add a custom font for some of the examples.
     let fonts = yak.dom().get_global_or_init(Fonts::default);

--- a/crates/demo/src/main.rs
+++ b/crates/demo/src/main.rs
@@ -61,7 +61,7 @@ async fn run() {
 
     // Create our yakui state. This is where our UI will be built, laid out, and
     // calculations for painting will happen.
-    let mut yak = yakui::State::new(yakui_app::Graphics::texture_reserver);
+    let mut yak = yakui::State::new();
 
     // By default, yakui_winit will measure the system's scale factor and pass
     // it to yakui.

--- a/crates/demo/src/main.rs
+++ b/crates/demo/src/main.rs
@@ -25,7 +25,7 @@ pub struct ExampleState {
     /// current time as an input.
     pub time: f32,
 
-    /// `TextureId` is a handle to a texture we previously gave to yakui. This
+    /// `ExternalTexture` is a handle to a texture we previously gave to yakui. This
     /// is an image that's usable from any of the examples.
     pub monkey: TextureId,
 

--- a/crates/demo/src/main.rs
+++ b/crates/demo/src/main.rs
@@ -61,7 +61,7 @@ async fn run() {
 
     // Create our yakui state. This is where our UI will be built, laid out, and
     // calculations for painting will happen.
-    let mut yak = yakui::State::new();
+    let mut yak = yakui::State::new(yakui_app::Graphics::texture_reserver);
 
     // By default, yakui_winit will measure the system's scale factor and pass
     // it to yakui.

--- a/crates/yakui-app/src/lib.rs
+++ b/crates/yakui-app/src/lib.rs
@@ -4,6 +4,7 @@ use winit::{
     event_loop::ControlFlow,
     window::Window,
 };
+use yakui::{paint::TextureReservation, TextureId};
 
 /// A helper for setting up rendering with winit and wgpu
 pub struct Graphics {
@@ -211,5 +212,9 @@ impl Graphics {
 
             _ => false,
         }
+    }
+
+    pub fn texture_reserver(_texture: &yakui::paint::Texture) -> (TextureId, TextureReservation) {
+        (yakui_wgpu::reserve_id(), TextureReservation::OnlyReserved)
     }
 }

--- a/crates/yakui-app/src/lib.rs
+++ b/crates/yakui-app/src/lib.rs
@@ -4,7 +4,6 @@ use winit::{
     event_loop::ControlFlow,
     window::Window,
 };
-use yakui::{paint::TextureReservation, TextureId};
 
 /// A helper for setting up rendering with winit and wgpu
 pub struct Graphics {
@@ -212,9 +211,5 @@ impl Graphics {
 
             _ => false,
         }
-    }
-
-    pub fn texture_reserver(_texture: &yakui::paint::Texture) -> (TextureId, TextureReservation) {
-        (yakui_wgpu::reserve_id(), TextureReservation::OnlyReserved)
     }
 }

--- a/crates/yakui-app/src/lib.rs
+++ b/crates/yakui-app/src/lib.rs
@@ -66,7 +66,7 @@ impl Graphics {
 
         // yakui_wgpu takes paint output from yakui and renders it for us using
         // wgpu.
-        let renderer = yakui_wgpu::State::new(&device, &queue, surface_config.format);
+        let renderer = yakui_wgpu::State::new(&device, surface_config.format);
 
         // yakui_winit processes winit events and applies them to our yakui
         // state.
@@ -106,6 +106,12 @@ impl Graphics {
             self.surface_config.height = new_size.height;
             self.surface.configure(&self.device, &self.surface_config);
         }
+    }
+
+    /// Adds a texture, uploading it to the Gpu, and returns a TextureId for it.
+    pub fn add_texture(&mut self, texture: yakui::paint::Texture) -> yakui::TextureId {
+        self.renderer
+            .add_texture(texture, &self.device, &self.queue)
     }
 
     #[cfg_attr(feature = "profiling", profiling::function)]

--- a/crates/yakui-core/src/dom/mod.rs
+++ b/crates/yakui-core/src/dom/mod.rs
@@ -154,6 +154,17 @@ impl Dom {
         globals.entry::<T>().or_insert_with(init).clone()
     }
 
+    /// Get a piece of DOM-global state.
+    ///
+    /// This is intended for any state that is global. It's not a perfect fit
+    /// for scoped state like themes.
+    pub fn get_global<T>(&self) -> Option<T>
+    where
+        T: 'static + Clone,
+    {
+        self.inner.globals.borrow_mut().get::<T>().cloned()
+    }
+
     /// Convenience method for calling [`Dom::begin_widget`] immediately
     /// followed by [`Dom::end_widget`].
     pub fn do_widget<T: Widget>(&self, props: T::Props) -> Response<T> {

--- a/crates/yakui-core/src/id.rs
+++ b/crates/yakui-core/src/id.rs
@@ -25,34 +25,6 @@ impl fmt::Debug for WidgetId {
     }
 }
 
-// #[derive(Clone, Debug, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// /// Either a yakui or an external texture -- this is given for user ease.
-// pub enum TextureId2 {
-//     /// A yakui originating texture.[PaintDom] has the HashMap to convert these to
-//     /// external textures.
-//     Yakui(YakuiTexture),
-//     /// An external originating texture.
-//     External(ExternalTexture),
-// }
-
-// impl From<YakuiTexture> for TextureId2 {
-//     fn from(o: YakuiTexture) -> Self {
-//         Self::Yakui(o)
-//     }
-// }
-
-// impl From<ExternalTexture> for TextureId2 {
-//     fn from(o: ExternalTexture) -> Self {
-//         Self::External(o)
-//     }
-// }
-
-// /// A yakui originating texture.[PaintDom] has the HashMap to convert these to
-// /// external textures.
-// #[derive(Clone, Debug, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[repr(transparent)]
-// pub struct YakuiTexture(u64);
-
 /// Identifies a texture that has been given to yakui to manage.
 #[derive(Clone, Debug, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(transparent)]
@@ -69,12 +41,7 @@ impl TextureId {
 
     /// Unwraps a [TextureId] into a `u64`.
     #[inline]
-    pub fn inner(self) -> u64 {
+    pub const fn inner(self) -> u64 {
         self.0
     }
 }
-
-// /// Identifies a texture that has been given to yakui to manage.
-// #[derive(Clone, Debug, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[repr(transparent)]
-// pub struct TextureId(u64);

--- a/crates/yakui-core/src/id.rs
+++ b/crates/yakui-core/src/id.rs
@@ -25,23 +25,14 @@ impl fmt::Debug for WidgetId {
     }
 }
 
-/// Identifies a texture that has been given to yakui to manage.
+/// Identifies a yakui texture.
 #[derive(Clone, Debug, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[repr(transparent)]
-pub struct TextureId(u64);
-
-impl TextureId {
-    /// Creates a new [TextureId].
-    ///
-    /// This is intended as a thin wrapper around a u64, which can mean whatever users want it to mean.
-    #[inline]
-    pub const fn new(index: u64) -> Self {
-        Self(index)
-    }
-
-    /// Unwraps a [TextureId] into a `u64`.
-    #[inline]
-    pub const fn inner(self) -> u64 {
-        self.0
-    }
+pub enum TextureId {
+    /// This is a user submitted texture. Yakui treats these as opaque u64s
+    User(u64),
+    /// This is a yakui originating texture.
+    Yak(Index),
+    /// This indicates the use of the White Pixel. This might be a real user supplied texture,
+    /// or it could be implement by users in other ways.
+    WhitePixel,
 }

--- a/crates/yakui-core/src/id.rs
+++ b/crates/yakui-core/src/id.rs
@@ -25,23 +25,56 @@ impl fmt::Debug for WidgetId {
     }
 }
 
+#[derive(Clone, Debug, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+/// Either a yakui or an external texture -- this is given for user ease.
+pub enum TextureId2 {
+    /// A yakui originating texture.[PaintDom] has the HashMap to convert these to
+    /// external textures.
+    Yakui(YakuiTexture),
+    /// An external originating texture.
+    External(ExternalTexture),
+}
+
+impl From<YakuiTexture> for TextureId2 {
+    fn from(o: YakuiTexture) -> Self {
+        Self::Yakui(o)
+    }
+}
+
+impl From<ExternalTexture> for TextureId2 {
+    fn from(o: ExternalTexture) -> Self {
+        Self::External(o)
+    }
+}
+
+/// A yakui originating texture.[PaintDom] has the HashMap to convert these to
+/// external textures.
+#[derive(Clone, Debug, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(transparent)]
+pub struct YakuiTexture(u64);
+
 /// Identifies a texture that has been given to yakui to manage.
 #[derive(Clone, Debug, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(transparent)]
-pub struct TextureId(u64);
+pub struct ExternalTexture(u64);
 
-impl TextureId {
-    /// Creates a new [TextureId].
-    ///
-    /// This is intended as a thin wrapper around a u64, which can mean whatever users want it to mean.
-    #[inline]
-    pub const fn new(index: u64) -> Self {
-        Self(index)
-    }
+// /// Identifies a texture that has been given to yakui to manage.
+// #[derive(Clone, Debug, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[repr(transparent)]
+// pub struct TextureId(u64);
 
-    /// Unwraps a [TextureId] into a `u64`.
-    #[inline]
-    pub fn inner(self) -> u64 {
-        self.0
-    }
-}
+// impl TextureId {
+//     /// Creates a new [TextureId].
+//     ///
+//     /// This is intended as a thin wrapper around a u64, which can mean whatever users want it to mean.
+//     #[inline]
+//     pub const fn new(index: u64) -> Self {
+//         Self(index)
+//     }
+
+//     /// Unwraps a [TextureId] into a `u64`.
+//     #[inline]
+//     pub fn inner(self) -> u64 {
+//         self.0
+//     }
+// }

--- a/crates/yakui-core/src/id.rs
+++ b/crates/yakui-core/src/id.rs
@@ -32,7 +32,4 @@ pub enum TextureId {
     User(u64),
     /// This is a yakui originating texture.
     Yak(Index),
-    /// This indicates the use of the White Pixel. This might be a real user supplied texture,
-    /// or it could be implement by users in other ways.
-    WhitePixel,
 }

--- a/crates/yakui-core/src/id.rs
+++ b/crates/yakui-core/src/id.rs
@@ -26,24 +26,22 @@ impl fmt::Debug for WidgetId {
 }
 
 /// Identifies a texture that has been given to yakui to manage.
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Debug, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(transparent)]
-pub struct TextureId(Index);
+pub struct TextureId(u64);
 
 impl TextureId {
+    /// Creates a new [TextureId].
+    ///
+    /// This is intended as a thin wrapper around a u64, which can mean whatever users want it to mean.
     #[inline]
-    pub(crate) fn new(index: Index) -> Self {
+    pub const fn new(index: u64) -> Self {
         Self(index)
     }
 
+    /// Unwraps a [TextureId] into a `u64`.
     #[inline]
-    pub(crate) fn index(&self) -> Index {
+    pub fn inner(self) -> u64 {
         self.0
-    }
-}
-
-impl fmt::Debug for TextureId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "TextureId({}, {})", self.0.slot(), self.0.generation())
     }
 }

--- a/crates/yakui-core/src/id.rs
+++ b/crates/yakui-core/src/id.rs
@@ -25,56 +25,56 @@ impl fmt::Debug for WidgetId {
     }
 }
 
-#[derive(Clone, Debug, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-/// Either a yakui or an external texture -- this is given for user ease.
-pub enum TextureId2 {
-    /// A yakui originating texture.[PaintDom] has the HashMap to convert these to
-    /// external textures.
-    Yakui(YakuiTexture),
-    /// An external originating texture.
-    External(ExternalTexture),
-}
+// #[derive(Clone, Debug, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// /// Either a yakui or an external texture -- this is given for user ease.
+// pub enum TextureId2 {
+//     /// A yakui originating texture.[PaintDom] has the HashMap to convert these to
+//     /// external textures.
+//     Yakui(YakuiTexture),
+//     /// An external originating texture.
+//     External(ExternalTexture),
+// }
 
-impl From<YakuiTexture> for TextureId2 {
-    fn from(o: YakuiTexture) -> Self {
-        Self::Yakui(o)
-    }
-}
+// impl From<YakuiTexture> for TextureId2 {
+//     fn from(o: YakuiTexture) -> Self {
+//         Self::Yakui(o)
+//     }
+// }
 
-impl From<ExternalTexture> for TextureId2 {
-    fn from(o: ExternalTexture) -> Self {
-        Self::External(o)
-    }
-}
+// impl From<ExternalTexture> for TextureId2 {
+//     fn from(o: ExternalTexture) -> Self {
+//         Self::External(o)
+//     }
+// }
 
-/// A yakui originating texture.[PaintDom] has the HashMap to convert these to
-/// external textures.
-#[derive(Clone, Debug, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[repr(transparent)]
-pub struct YakuiTexture(u64);
+// /// A yakui originating texture.[PaintDom] has the HashMap to convert these to
+// /// external textures.
+// #[derive(Clone, Debug, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[repr(transparent)]
+// pub struct YakuiTexture(u64);
 
 /// Identifies a texture that has been given to yakui to manage.
 #[derive(Clone, Debug, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(transparent)]
-pub struct ExternalTexture(u64);
+pub struct TextureId(u64);
+
+impl TextureId {
+    /// Creates a new [TextureId].
+    ///
+    /// This is intended as a thin wrapper around a u64, which can mean whatever users want it to mean.
+    #[inline]
+    pub const fn new(index: u64) -> Self {
+        Self(index)
+    }
+
+    /// Unwraps a [TextureId] into a `u64`.
+    #[inline]
+    pub fn inner(self) -> u64 {
+        self.0
+    }
+}
 
 // /// Identifies a texture that has been given to yakui to manage.
 // #[derive(Clone, Debug, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[repr(transparent)]
 // pub struct TextureId(u64);
-
-// impl TextureId {
-//     /// Creates a new [TextureId].
-//     ///
-//     /// This is intended as a thin wrapper around a u64, which can mean whatever users want it to mean.
-//     #[inline]
-//     pub const fn new(index: u64) -> Self {
-//         Self(index)
-//     }
-
-//     /// Unwraps a [TextureId] into a `u64`.
-//     #[inline]
-//     pub fn inner(self) -> u64 {
-//         self.0
-//     }
-// }

--- a/crates/yakui-core/src/paint/paint_dom.rs
+++ b/crates/yakui-core/src/paint/paint_dom.rs
@@ -108,7 +108,11 @@ impl PaintDom {
     /// The texture will be marked as dirty, which may cause it to be reuploaded
     /// to the GPU by the renderer.
     pub fn modify_texture(&mut self, id: thunderdome::Index) {
-        self.texture_deltas.insert(id, TextureEdit::Modify);
+        if self.textures.contains(id) {
+            // only put modify in there if there's no other command (ie, if we add and modify)
+            // in the same frame, we only need to say "add"
+            self.texture_deltas.entry(id).or_insert(TextureEdit::Modify);
+        }
     }
 
     /// Remove a texture from the Paint DOM.

--- a/crates/yakui-core/src/paint/primitives.rs
+++ b/crates/yakui-core/src/paint/primitives.rs
@@ -2,7 +2,7 @@ use glam::{Vec2, Vec4};
 
 use crate::{
     geometry::{Color, Rect},
-    ExternalTexture, TextureId2,
+    TextureId,
 };
 
 #[non_exhaustive]
@@ -10,7 +10,7 @@ use crate::{
 pub struct PaintRect {
     pub rect: Rect,
     pub color: Color,
-    pub texture: Option<(TextureId2, Rect)>,
+    pub texture: Option<(TextureId, Rect)>,
     pub pipeline: Pipeline,
 }
 
@@ -36,7 +36,7 @@ impl PaintRect {
 pub struct PaintMesh<V, I> {
     pub vertices: V,
     pub indices: I,
-    pub texture: Option<(TextureId2, Rect)>,
+    pub texture: Option<(TextureId, Rect)>,
     pub pipeline: Pipeline,
 }
 
@@ -63,18 +63,18 @@ where
 pub struct PaintCall {
     pub vertices: Vec<Vertex>,
     pub indices: Vec<u16>,
-    pub texture: Option<ExternalTexture>,
+    pub texture: Option<TextureId>,
     pub pipeline: Pipeline,
 }
 
 impl PaintCall {
     /// Create a new empty `PaintCall`.
-    pub fn new() -> Self {
+    pub fn new(pipeline: Pipeline) -> Self {
         Self {
             vertices: Vec::new(),
             indices: Vec::new(),
             texture: None,
-            pipeline: Pipeline::Main,
+            pipeline,
         }
     }
 }

--- a/crates/yakui-core/src/paint/primitives.rs
+++ b/crates/yakui-core/src/paint/primitives.rs
@@ -82,6 +82,7 @@ impl PaintCall {
 #[derive(Debug, Clone, Copy)]
 #[non_exhaustive]
 #[allow(missing_docs)]
+#[repr(C)]
 pub struct Vertex {
     pub position: Vec2,
     pub texcoord: Vec2,

--- a/crates/yakui-core/src/paint/primitives.rs
+++ b/crates/yakui-core/src/paint/primitives.rs
@@ -1,14 +1,16 @@
 use glam::{Vec2, Vec4};
 
-use crate::geometry::{Color, Rect};
-use crate::id::TextureId;
+use crate::{
+    geometry::{Color, Rect},
+    ExternalTexture, TextureId2,
+};
 
 #[non_exhaustive]
 #[allow(missing_docs)]
 pub struct PaintRect {
     pub rect: Rect,
     pub color: Color,
-    pub texture: Option<(TextureId, Rect)>,
+    pub texture: Option<(TextureId2, Rect)>,
     pub pipeline: Pipeline,
 }
 
@@ -34,7 +36,7 @@ impl PaintRect {
 pub struct PaintMesh<V, I> {
     pub vertices: V,
     pub indices: I,
-    pub texture: Option<(TextureId, Rect)>,
+    pub texture: Option<(TextureId2, Rect)>,
     pub pipeline: Pipeline,
 }
 
@@ -61,7 +63,7 @@ where
 pub struct PaintCall {
     pub vertices: Vec<Vertex>,
     pub indices: Vec<u16>,
-    pub texture: Option<TextureId>,
+    pub texture: Option<ExternalTexture>,
     pub pipeline: Pipeline,
 }
 

--- a/crates/yakui-core/src/paint/primitives.rs
+++ b/crates/yakui-core/src/paint/primitives.rs
@@ -82,7 +82,6 @@ impl PaintCall {
 #[derive(Debug, Clone, Copy)]
 #[non_exhaustive]
 #[allow(missing_docs)]
-#[repr(C)]
 pub struct Vertex {
     pub position: Vec2,
     pub texcoord: Vec2,

--- a/crates/yakui-core/src/paint/texture.rs
+++ b/crates/yakui-core/src/paint/texture.rs
@@ -1,6 +1,7 @@
 use glam::UVec2;
 
 /// A texture that is managed by yakui.
+#[derive(Clone)]
 pub struct Texture {
     format: TextureFormat,
     size: UVec2,
@@ -11,10 +12,6 @@ pub struct Texture {
 
     /// How to filter the texture when it needs to be magnified (made larger)
     pub mag_filter: TextureFilter,
-
-    /// Generation attached to the texture to indicate that it has been
-    /// completely invalidated and should be reuploaded.
-    pub(super) generation: u8,
 }
 
 impl std::fmt::Debug for Texture {
@@ -24,7 +21,6 @@ impl std::fmt::Debug for Texture {
             .field("size", &self.size)
             .field("min_filter", &self.min_filter)
             .field("mag_filter", &self.mag_filter)
-            .field("generation", &self.generation)
             .finish_non_exhaustive()
     }
 }
@@ -60,7 +56,6 @@ impl Texture {
             data,
             min_filter: TextureFilter::Nearest,
             mag_filter: TextureFilter::Linear,
-            generation: 0,
         }
     }
 
@@ -82,11 +77,5 @@ impl Texture {
     /// The texture's format.
     pub fn format(&self) -> TextureFormat {
         self.format
-    }
-
-    /// The texture's generation. This is incremented every time the texture has
-    /// potentially been modified.
-    pub fn generation(&self) -> u8 {
-        self.generation
     }
 }

--- a/crates/yakui-core/src/state.rs
+++ b/crates/yakui-core/src/state.rs
@@ -2,10 +2,9 @@ use crate::context;
 use crate::dom::Dom;
 use crate::event::{Event, EventResponse};
 use crate::geometry::Rect;
-use crate::id::TextureId;
 use crate::input::InputState;
 use crate::layout::LayoutDom;
-use crate::paint::{PaintDom, Texture};
+use crate::paint::PaintDom;
 
 /// The entrypoint for yakui.
 #[derive(Debug)]
@@ -47,16 +46,6 @@ impl State {
         response == EventResponse::Sink
     }
 
-    /// Creates a texture for use within yakui.
-    pub fn add_texture(&mut self, texture: Texture) -> TextureId {
-        self.paint.add_texture(texture)
-    }
-
-    /// Returns an iterator of all textures managed by yakui.
-    pub fn textures(&self) -> impl Iterator<Item = (TextureId, &Texture)> {
-        self.paint.textures()
-    }
-
     /// Set the size of the viewport in physical units.
     pub fn set_unscaled_viewport(&mut self, view: Rect) {
         self.layout.set_unscaled_viewport(view);
@@ -79,6 +68,7 @@ impl State {
     /// When finished, call [`Dom::finish`].
     pub fn start(&mut self) {
         self.dom.start();
+        self.paint.start();
         context::bind_dom(&self.dom);
         context::bind_input(&self.input);
     }

--- a/crates/yakui-core/src/state.rs
+++ b/crates/yakui-core/src/state.rs
@@ -20,7 +20,7 @@ impl State {
     #[allow(clippy::new_without_default)]
     pub fn new<T>(texture_reservation: T) -> Self
     where
-        T: Fn(&Texture) -> (TextureId, TextureReservation) + 'static,
+        T: FnMut(&Texture) -> (TextureId, TextureReservation) + 'static,
     {
         Self {
             dom: Dom::new(),

--- a/crates/yakui-core/src/state.rs
+++ b/crates/yakui-core/src/state.rs
@@ -1,10 +1,10 @@
+use crate::context;
 use crate::dom::Dom;
 use crate::event::{Event, EventResponse};
 use crate::geometry::Rect;
 use crate::input::InputState;
 use crate::layout::LayoutDom;
-use crate::paint::{PaintDom, Texture, TextureReservation};
-use crate::{context, TextureId};
+use crate::paint::PaintDom;
 
 /// The entrypoint for yakui.
 #[derive(Debug)]
@@ -18,14 +18,11 @@ pub struct State {
 impl State {
     /// Creates a new yakui State.
     #[allow(clippy::new_without_default)]
-    pub fn new<T>(texture_reservation: T) -> Self
-    where
-        T: FnMut(&Texture) -> (TextureId, TextureReservation) + 'static,
-    {
+    pub fn new() -> Self {
         Self {
             dom: Dom::new(),
             layout: LayoutDom::new(),
-            paint: PaintDom::new(texture_reservation),
+            paint: PaintDom::new(),
             input: InputState::new(),
         }
     }

--- a/crates/yakui-core/src/state.rs
+++ b/crates/yakui-core/src/state.rs
@@ -1,10 +1,10 @@
-use crate::context;
 use crate::dom::Dom;
 use crate::event::{Event, EventResponse};
 use crate::geometry::Rect;
 use crate::input::InputState;
 use crate::layout::LayoutDom;
-use crate::paint::PaintDom;
+use crate::paint::{PaintDom, Texture, TextureReservation};
+use crate::{context, TextureId};
 
 /// The entrypoint for yakui.
 #[derive(Debug)]
@@ -18,11 +18,14 @@ pub struct State {
 impl State {
     /// Creates a new yakui State.
     #[allow(clippy::new_without_default)]
-    pub fn new() -> Self {
+    pub fn new<T>(texture_reservation: T) -> Self
+    where
+        T: Fn(&Texture) -> (TextureId, TextureReservation) + 'static,
+    {
         Self {
             dom: Dom::new(),
             layout: LayoutDom::new(),
-            paint: PaintDom::new(),
+            paint: PaintDom::new(texture_reservation),
             input: InputState::new(),
         }
     }

--- a/crates/yakui-test/src/lib.rs
+++ b/crates/yakui-test/src/lib.rs
@@ -24,7 +24,9 @@ macro_rules! run {
         let _guard = settings.bind_to_scope();
 
         let test = $test;
-        let mut state = ::yakui_test::yakui_core::State::new();
+        let mut state = ::yakui_test::yakui_core::State::new(|_| {
+            (::yakui_core::TextureId::new(0), ::yakui_core::paint::TextureReservation::Completed)
+        });
         state.set_unscaled_viewport(test.viewport);
         state.start();
         $body

--- a/crates/yakui-test/src/lib.rs
+++ b/crates/yakui-test/src/lib.rs
@@ -24,9 +24,7 @@ macro_rules! run {
         let _guard = settings.bind_to_scope();
 
         let test = $test;
-        let mut state = ::yakui_test::yakui_core::State::new(|_| {
-            (::yakui_core::TextureId::new(0), ::yakui_core::paint::TextureReservation::Completed)
-        });
+        let mut state = ::yakui_test::yakui_core::State::new();
         state.set_unscaled_viewport(test.viewport);
         state.start();
         $body

--- a/crates/yakui-to-image/src/lib.rs
+++ b/crates/yakui-to-image/src/lib.rs
@@ -24,6 +24,6 @@ pub fn paint_and_save_to<P: AsRef<Path>>(state: &mut yakui_core::State, path: P)
 
 pub fn paint(state: &mut yakui_core::State) -> RgbaImage {
     let graphics = pollster::block_on(Graphics::new());
-    let mut renderer = yakui_wgpu::State::new(&graphics.device, &graphics.queue, graphics.format);
+    let mut renderer = yakui_wgpu::State::new(&graphics.device, graphics.format);
     graphics.paint(state, &mut renderer)
 }

--- a/crates/yakui-wgpu/src/lib.rs
+++ b/crates/yakui-wgpu/src/lib.rs
@@ -200,7 +200,7 @@ impl State {
             return;
         }
 
-        self.update_textures(device, paint, queue);
+        self.update_textures(paint, device, queue);
         self.update_buffers(device, paint);
         let vertices = self.vertices.upload(device, queue);
         let indices = self.indices.upload(device, queue);

--- a/crates/yakui-wgpu/src/lib.rs
+++ b/crates/yakui-wgpu/src/lib.rs
@@ -12,7 +12,7 @@ use std::sync::atomic::AtomicU64;
 use buffer::Buffer;
 use bytemuck::{Pod, Zeroable};
 use yakui_core::geometry::{Vec2, Vec4};
-use yakui_core::paint::{PaintDom, Pipeline, Texture, TextureEdit};
+use yakui_core::paint::{PaintDom, Pipeline, Texture, TextureDelta};
 use yakui_core::TextureId;
 
 use self::samplers::Samplers;
@@ -194,7 +194,7 @@ impl State {
         profiling::scope!("yakui-wgpu paint_with_encoder");
 
         let paint = state.paint();
-        self.update_textures(paint.texture_edits(), device, queue);
+        self.update_textures(paint.texture_deltas(), device, queue);
 
         if paint.calls().is_empty() {
             return;
@@ -307,7 +307,7 @@ impl State {
 
     fn update_textures(
         &mut self,
-        texture_edits: &[TextureEdit],
+        texture_edits: &[TextureDelta],
         device: &wgpu::Device,
         queue: &wgpu::Queue,
     ) {
@@ -315,11 +315,11 @@ impl State {
 
         for texture_edit in texture_edits {
             match texture_edit {
-                TextureEdit::Add(id, texture) => {
+                TextureDelta::Add(id, texture) => {
                     let texture = GpuTexture::new(device, queue, texture);
                     self.textures.insert(*id, texture);
                 }
-                TextureEdit::Modify(id, texture) => {
+                TextureDelta::Modify(id, texture) => {
                     let gpu_texture = self
                         .textures
                         .get_mut(id)
@@ -327,7 +327,7 @@ impl State {
 
                     gpu_texture.update(device, queue, texture);
                 }
-                TextureEdit::Remove(_) => {
+                TextureDelta::Remove(_) => {
                     todo!("FOR PR REVIEW -- this writer doesn't know wgpu and so does not know how to implement this!")
                 }
             }

--- a/crates/yakui-wgpu/src/texture.rs
+++ b/crates/yakui-wgpu/src/texture.rs
@@ -10,7 +10,6 @@ pub(crate) struct GpuTexture {
     pub view: wgpu::TextureView,
     pub min_filter: wgpu::FilterMode,
     pub mag_filter: wgpu::FilterMode,
-    generation: u8,
 }
 
 impl GpuTexture {
@@ -55,21 +54,11 @@ impl GpuTexture {
             view: gpu_view,
             min_filter,
             mag_filter,
-            generation: texture.generation(),
         }
     }
 
     // Update the GpuTexture if the given Texture has newer data.
-    pub fn update_if_newer(
-        &mut self,
-        device: &wgpu::Device,
-        queue: &wgpu::Queue,
-        texture: &Texture,
-    ) {
-        if self.generation == texture.generation() {
-            return;
-        }
-
+    pub fn update(&mut self, device: &wgpu::Device, queue: &wgpu::Queue, texture: &Texture) {
         if self.size != texture.size() || self.format != texture.format() {
             *self = Self::new(device, queue, texture);
             return;

--- a/crates/yakui-widgets/src/lib.rs
+++ b/crates/yakui-widgets/src/lib.rs
@@ -8,6 +8,7 @@ mod icons;
 mod text_renderer;
 
 pub use text_renderer::{GlyphCache, LateBindingGlyphCache, TextGlobalState};
+use yakui_core::paint::TextureReservation;
 
 pub mod colors;
 pub mod font;
@@ -25,7 +26,10 @@ pub struct DocTest {
 
 impl DocTest {
     pub fn start() -> Self {
-        let mut state = yakui_core::State::new();
+        let mut state = yakui_core::State::new(|_| {
+            // this is a dummy response
+            (yakui_core::TextureId::new(0), TextureReservation::Completed)
+        });
         state.start();
         Self { state }
     }

--- a/crates/yakui-widgets/src/lib.rs
+++ b/crates/yakui-widgets/src/lib.rs
@@ -7,6 +7,8 @@
 mod icons;
 mod text_renderer;
 
+pub use text_renderer::{GlyphCache, LateBindingGlyphCache, TextGlobalState};
+
 pub mod colors;
 pub mod font;
 pub mod shorthand;

--- a/crates/yakui-widgets/src/lib.rs
+++ b/crates/yakui-widgets/src/lib.rs
@@ -8,7 +8,6 @@ mod icons;
 mod text_renderer;
 
 pub use text_renderer::{GlyphCache, LateBindingGlyphCache, TextGlobalState};
-use yakui_core::paint::TextureReservation;
 
 pub mod colors;
 pub mod font;
@@ -26,10 +25,7 @@ pub struct DocTest {
 
 impl DocTest {
     pub fn start() -> Self {
-        let mut state = yakui_core::State::new(|_| {
-            // this is a dummy response
-            (yakui_core::TextureId::new(0), TextureReservation::Completed)
-        });
+        let mut state = yakui_core::State::new();
         state.start();
         Self { state }
     }

--- a/crates/yakui-widgets/src/text_renderer.rs
+++ b/crates/yakui-widgets/src/text_renderer.rs
@@ -6,7 +6,7 @@ use fontdue::layout::GlyphRasterConfig;
 use fontdue::Font;
 use yakui_core::geometry::{URect, UVec2};
 use yakui_core::paint::{PaintDom, Texture, TextureFormat};
-use yakui_core::TextureId;
+use yakui_core::TextureId2;
 
 #[derive(Clone)]
 pub struct TextGlobalState {
@@ -33,7 +33,7 @@ pub trait GlyphCache {
         paint: &mut PaintDom,
         font: &Font,
         key: GlyphRasterConfig,
-    ) -> Result<(TextureId, URect), GlyphCacheErr>;
+    ) -> Result<(TextureId2, URect), GlyphCacheErr>;
 
     fn texture_size(&self, font: &Font, key: &GlyphRasterConfig) -> UVec2;
 }
@@ -55,7 +55,7 @@ impl std::error::Error for GlyphCacheErr {}
 
 #[derive(Debug)]
 pub struct LateBindingGlyphCache {
-    font_atlas_id: Option<TextureId>,
+    font_atlas_id: Option<TextureId2>,
     font_atlas: Texture,
     glyphs: HashMap<GlyphRasterConfig, URect>,
     next_pos: UVec2,
@@ -88,7 +88,7 @@ impl GlyphCache for LateBindingGlyphCache {
         paint: &mut PaintDom,
         font: &Font,
         key: GlyphRasterConfig,
-    ) -> Result<(TextureId, URect), GlyphCacheErr> {
+    ) -> Result<(TextureId2, URect), GlyphCacheErr> {
         let font_atlas_id = self
             .font_atlas_id
             .ok_or(GlyphCacheErr::NeedsTextureAllocation)?;

--- a/crates/yakui-widgets/src/text_renderer.rs
+++ b/crates/yakui-widgets/src/text_renderer.rs
@@ -6,7 +6,7 @@ use fontdue::layout::GlyphRasterConfig;
 use fontdue::Font;
 use yakui_core::geometry::{URect, UVec2};
 use yakui_core::paint::{PaintDom, Texture, TextureFormat};
-use yakui_core::TextureId2;
+use yakui_core::TextureId;
 
 #[derive(Clone)]
 pub struct TextGlobalState {
@@ -33,7 +33,7 @@ pub trait GlyphCache {
         paint: &mut PaintDom,
         font: &Font,
         key: GlyphRasterConfig,
-    ) -> Result<(TextureId2, URect), GlyphCacheErr>;
+    ) -> Result<(TextureId, URect), GlyphCacheErr>;
 
     fn texture_size(&self, font: &Font, key: &GlyphRasterConfig) -> UVec2;
 }
@@ -55,7 +55,7 @@ impl std::error::Error for GlyphCacheErr {}
 
 #[derive(Debug)]
 pub struct LateBindingGlyphCache {
-    font_atlas_id: Option<TextureId2>,
+    font_atlas_id: Option<TextureId>,
     font_atlas: Texture,
     glyphs: HashMap<GlyphRasterConfig, URect>,
     next_pos: UVec2,
@@ -88,7 +88,7 @@ impl GlyphCache for LateBindingGlyphCache {
         paint: &mut PaintDom,
         font: &Font,
         key: GlyphRasterConfig,
-    ) -> Result<(TextureId2, URect), GlyphCacheErr> {
+    ) -> Result<(TextureId, URect), GlyphCacheErr> {
         let font_atlas_id = self
             .font_atlas_id
             .ok_or(GlyphCacheErr::NeedsTextureAllocation)?;

--- a/crates/yakui-widgets/src/widgets/render_text.rs
+++ b/crates/yakui-widgets/src/widgets/render_text.rs
@@ -170,24 +170,27 @@ pub fn paint_text(
         None => return,
     };
 
-    let text_global = dom
-        .get_global::<TextGlobalState>()
-        .expect("please initialize the glyph cache");
+    let text_global = dom.get_global_or_init(TextGlobalState::new_late_binding);
     let mut glyph_cache = text_global.glyph_cache.borrow_mut();
 
     for glyph in text_layout.glyphs() {
-        let tex_rect = glyph_cache
-            .get_or_insert(paint, &font, glyph.key)
-            .as_rect()
-            .div_vec2(glyph_cache.texture_size().as_vec2());
+        match glyph_cache.get_or_insert(paint, &font, glyph.key) {
+            Ok((texture_id, tex_rect)) => {
+                let tex_rect = tex_rect
+                    .as_rect()
+                    .div_vec2(glyph_cache.texture_size(&font, &glyph.key).as_vec2());
 
-        let size = Vec2::new(glyph.width as f32, glyph.height as f32) / layout.scale_factor();
-        let pos = pos + Vec2::new(glyph.x, glyph.y) / layout.scale_factor();
+                let size =
+                    Vec2::new(glyph.width as f32, glyph.height as f32) / layout.scale_factor();
+                let pos = pos + Vec2::new(glyph.x, glyph.y) / layout.scale_factor();
 
-        let mut rect = PaintRect::new(Rect::from_pos_size(pos, size));
-        rect.color = color;
-        rect.texture = Some((glyph_cache.font_atlas_id(), tex_rect));
-        rect.pipeline = Pipeline::Text;
-        paint.add_rect(rect);
+                let mut rect = PaintRect::new(Rect::from_pos_size(pos, size));
+                rect.color = color;
+                rect.texture = Some((texture_id, tex_rect));
+                rect.pipeline = Pipeline::Text;
+                paint.add_rect(rect);
+            }
+            Err(_) => panic!("oh no! DO NOT PR"),
+        }
     }
 }

--- a/crates/yakui-widgets/src/widgets/render_text.rs
+++ b/crates/yakui-widgets/src/widgets/render_text.rs
@@ -170,22 +170,23 @@ pub fn paint_text(
         None => return,
     };
 
-    let text_global = dom.get_global_or_init(TextGlobalState::new);
+    let text_global = dom
+        .get_global::<TextGlobalState>()
+        .expect("please initialize the glyph cache");
     let mut glyph_cache = text_global.glyph_cache.borrow_mut();
-    glyph_cache.ensure_texture(paint);
 
     for glyph in text_layout.glyphs() {
         let tex_rect = glyph_cache
             .get_or_insert(paint, &font, glyph.key)
             .as_rect()
-            .div_vec2(glyph_cache.texture_size.as_vec2());
+            .div_vec2(glyph_cache.texture_size().as_vec2());
 
         let size = Vec2::new(glyph.width as f32, glyph.height as f32) / layout.scale_factor();
         let pos = pos + Vec2::new(glyph.x, glyph.y) / layout.scale_factor();
 
         let mut rect = PaintRect::new(Rect::from_pos_size(pos, size));
         rect.color = color;
-        rect.texture = Some((glyph_cache.texture.unwrap(), tex_rect));
+        rect.texture = Some((glyph_cache.font_atlas_id(), tex_rect));
         rect.pipeline = Pipeline::Text;
         paint.add_rect(rect);
     }

--- a/crates/yakui-widgets/src/widgets/render_text.rs
+++ b/crates/yakui-widgets/src/widgets/render_text.rs
@@ -174,23 +174,19 @@ pub fn paint_text(
     let mut glyph_cache = text_global.glyph_cache.borrow_mut();
 
     for glyph in text_layout.glyphs() {
-        match glyph_cache.get_or_insert(paint, &font, glyph.key) {
-            Ok((texture_id, tex_rect)) => {
-                let tex_rect = tex_rect
-                    .as_rect()
-                    .div_vec2(glyph_cache.texture_size(&font, &glyph.key).as_vec2());
+        let (texture_id, tex_rect) = glyph_cache.get_or_insert(paint, &font, glyph.key);
 
-                let size =
-                    Vec2::new(glyph.width as f32, glyph.height as f32) / layout.scale_factor();
-                let pos = pos + Vec2::new(glyph.x, glyph.y) / layout.scale_factor();
+        let tex_rect = tex_rect
+            .as_rect()
+            .div_vec2(glyph_cache.texture_size(&font, &glyph.key).as_vec2());
 
-                let mut rect = PaintRect::new(Rect::from_pos_size(pos, size));
-                rect.color = color;
-                rect.texture = Some((texture_id, tex_rect));
-                rect.pipeline = Pipeline::Text;
-                paint.add_rect(rect);
-            }
-            Err(_) => panic!("oh no! DO NOT PR"),
-        }
+        let size = Vec2::new(glyph.width as f32, glyph.height as f32) / layout.scale_factor();
+        let pos = pos + Vec2::new(glyph.x, glyph.y) / layout.scale_factor();
+
+        let mut rect = PaintRect::new(Rect::from_pos_size(pos, size));
+        rect.color = color;
+        rect.texture = Some((texture_id, tex_rect));
+        rect.pipeline = Pipeline::Text;
+        paint.add_rect(rect);
     }
 }


### PR DESCRIPTION
This refactors TextureId creation in Yakui, so that Yakui entirely relies upon the host renderer for texture id creation.

Here is the current workflow:

First, when users create `yakui::State`, they must provide a texture reservation function. This isn't terribly elegant, and i have some thoughts to allow users to skip this stage, but that's how we start things right now. This doesn't mean users need to uplaod textures (though they can, and return a variant of an enum to signify that they have), but it *does* mean that users need to reserve a texture id. You can see in `yakui_wgpu` how this may be trivially implemented in that scheme. In my own game engine, I just use slabs id reservation system with an Arc'd texture manager.

Inside yakui, when a widget needs a new texture (for example, very quickly the text renderer needs to allocate its atlas), it asks for an ID. `yakui_wgpu` doesn't upload textures when its asked to reserve the ID, so it only reserves the ID and then later will get a `TextureDelta::Add` event, which is when it actually uploads the texture.

Finally, `calls` outputs textures which the renderer at this point knows it always is aware of.

--

The big shortcoming rn is that this loaded function can be difficult for ~some~ users to write, but at least for me, this is not hard. I experimented with yakui keeping an internal id space (which it can allocate to freely), and an external id space, but (unlike egui which does this) we only use one pass to `paint` *and* generate our IDs, so we actually have *already* generated our `PaintCall` before we have an ID in user space. The only solution if we maintain that design is to later take our PaintCall (which has "InternalId" in it) and transmogrify it into `ExternalPaintCall` (with "external id" in it). Either we do that, or the user does that, but either way, there's a big lookup stage involved for *every* paint call.

This also encouraged me to rewrite the `GlyphCache`. I renamed it `LateBindingGlyphCache` and made it the default -- moreover, I made it into a trait object, which allows me to write a glyph cache as a user which already has all the glyphs etched onto it, and where every location is known. That's convenient to me, since I do my font atlas creation offline, and don't want to waste the effort of making it several times! I didn't make that yet, since more font work is needed before then. 
However, doing this work also helped the default cause tremendously -- we're not quite there yet, but `LateBindingGlyphCache` is very well set up to have more than one texture in its cache.

--

How do we get rid of requiring a loader function?

I suspect the simplest option is for us to provide a default function, and allow users to override that function as they wish (and they will wish! which is why I haven't done it here), probably being one where we assign to numbers from u64 backwards. This also leads us to wonder about Internal vs. External ids, but see the sections above where I ran into pain points there.

--

Okay, that's mostly what I did! Let me know if you have any questions or concerns