### PR TITLE
Introduce viewport widget

### DIFF
--- a/crates/yakui-widgets/src/widgets/mod.rs
+++ b/crates/yakui-widgets/src/widgets/mod.rs
@@ -27,6 +27,7 @@ mod state;
 mod text;
 mod textbox;
 mod unconstrained_box;
+mod viewport;
 mod window;
 
 pub use self::align::*;
@@ -58,4 +59,5 @@ pub use self::state::*;
 pub use self::text::*;
 pub use self::textbox::*;
 pub use self::unconstrained_box::*;
+pub use self::viewport::*;
 pub use self::window::*;

--- a/crates/yakui-widgets/src/widgets/viewport.rs
+++ b/crates/yakui-widgets/src/widgets/viewport.rs
@@ -1,0 +1,44 @@
+use yakui_core::{
+    geometry::{Constraints, FlexFit, Vec2},
+    widget::{LayoutContext, Widget},
+    Response,
+};
+
+/// Occupies the largest possible space, draws nothing, and consumes no inputs
+///
+/// Capture `Viewport.show().id`, then look it up in the final `LayoutDom` to find its
+/// dimensions. Useful identifying a viewport for non-GUI rendering.
+#[derive(Debug, Default)]
+pub struct Viewport;
+
+impl Viewport {
+    pub fn show(&self) -> Response<Self> {
+        crate::util::widget::<Self>(())
+    }
+}
+
+impl Widget for Viewport {
+    type Props = ();
+    type Response = ();
+
+    fn new() -> Self {
+        Self
+    }
+
+    fn update(&mut self, (): ()) {}
+
+    fn layout(&self, _: LayoutContext<'_>, constraints: Constraints) -> Vec2 {
+        constraints
+            .max
+            .as_ref()
+            .map(|x| match x.is_infinite() {
+                true => 0.0,
+                false => x,
+            })
+            .into()
+    }
+
+    fn flex(&self) -> (u32, FlexFit) {
+        (1, FlexFit::Tight)
+    }
+}


### PR DESCRIPTION
I opted for concision rather than maintaining the same large family of aliases/etc that seem to be common in other widgets. Unsure if `layout` is the right way to do this; it feels like it's baking in some assumptions about how the list widget works.