### PR TITLE
Allow Widget::Props to borrow data

### DIFF
--- a/crates/yakui-core/src/dom/dummy.rs
+++ b/crates/yakui-core/src/dom/dummy.rs
@@ -6,7 +6,7 @@ use crate::widget::Widget;
 pub(crate) struct DummyWidget;
 
 impl Widget for DummyWidget {
-    type Props = ();
+    type Props<'a> = ();
     type Response = ();
 
     #[inline]
@@ -15,5 +15,5 @@ impl Widget for DummyWidget {
     }
 
     #[inline]
-    fn update(&mut self, _props: Self::Props) -> Self::Response {}
+    fn update(&mut self, _props: Self::Props<'_>) -> Self::Response {}
 }

--- a/crates/yakui-core/src/dom/mod.rs
+++ b/crates/yakui-core/src/dom/mod.rs
@@ -175,7 +175,7 @@ impl Dom {
 
     /// Convenience method for calling [`Dom::begin_widget`] immediately
     /// followed by [`Dom::end_widget`].
-    pub fn do_widget<T: Widget>(&self, props: T::Props) -> Response<T::Response> {
+    pub fn do_widget<T: Widget>(&self, props: T::Props<'_>) -> Response<T::Response> {
         let response = self.begin_widget::<T>(props);
         self.end_widget::<T>(response.id);
         response
@@ -184,7 +184,7 @@ impl Dom {
     /// Begin building a widget with the given type and props.
     ///
     /// After calling this method, children can be added to this widget.
-    pub fn begin_widget<T: Widget>(&self, props: T::Props) -> Response<T::Response> {
+    pub fn begin_widget<T: Widget>(&self, props: T::Props<'_>) -> Response<T::Response> {
         log::trace!("begin_widget::<{}>({props:#?}", type_name::<T>());
 
         let (id, mut widget) = {

--- a/crates/yakui-core/src/dom/mod.rs
+++ b/crates/yakui-core/src/dom/mod.rs
@@ -175,7 +175,7 @@ impl Dom {
 
     /// Convenience method for calling [`Dom::begin_widget`] immediately
     /// followed by [`Dom::end_widget`].
-    pub fn do_widget<T: Widget>(&self, props: T::Props) -> Response<T> {
+    pub fn do_widget<T: Widget>(&self, props: T::Props) -> Response<T::Response> {
         let response = self.begin_widget::<T>(props);
         self.end_widget::<T>(response.id);
         response
@@ -184,7 +184,7 @@ impl Dom {
     /// Begin building a widget with the given type and props.
     ///
     /// After calling this method, children can be added to this widget.
-    pub fn begin_widget<T: Widget>(&self, props: T::Props) -> Response<T> {
+    pub fn begin_widget<T: Widget>(&self, props: T::Props) -> Response<T::Response> {
         log::trace!("begin_widget::<{}>({props:#?}", type_name::<T>());
 
         let (id, mut widget) = {

--- a/crates/yakui-core/src/dom/root.rs
+++ b/crates/yakui-core/src/dom/root.rs
@@ -5,14 +5,14 @@ use crate::widget::{LayoutContext, Widget};
 pub struct RootWidget;
 
 impl Widget for RootWidget {
-    type Props = ();
+    type Props<'a> = ();
     type Response = ();
 
     fn new() -> Self {
         Self
     }
 
-    fn update(&mut self, _props: Self::Props) -> Self::Response {}
+    fn update(&mut self, _props: Self::Props<'_>) -> Self::Response {}
 
     fn layout(&self, mut ctx: LayoutContext<'_>, constraints: Constraints) -> glam::Vec2 {
         ctx.layout.new_layer(ctx.dom);

--- a/crates/yakui-core/src/response.rs
+++ b/crates/yakui-core/src/response.rs
@@ -1,40 +1,39 @@
 use std::ops::{Deref, DerefMut};
 
 use crate::id::WidgetId;
-use crate::widget::Widget;
 
 /// Wraps the response returned by a widget when it is updated.
 ///
 /// Widget responses can convey information like whether the widget was clicked,
 /// is currently hovered, or had an update to its state.
 #[derive(Debug)]
-pub struct Response<T: Widget> {
-    inner: T::Response,
+pub struct Response<T> {
+    inner: T,
 
     /// The ID of the widget that responded.
     pub id: WidgetId,
 }
 
-impl<T: Widget> Response<T> {
-    pub(crate) fn new(id: WidgetId, inner: T::Response) -> Self {
+impl<T> Response<T> {
+    pub(crate) fn new(id: WidgetId, inner: T) -> Self {
         Self { id, inner }
     }
 
     /// Unwrap the response into the underlying type.
-    pub fn into_inner(self) -> T::Response {
+    pub fn into_inner(self) -> T {
         self.inner
     }
 }
 
-impl<T: Widget> Deref for Response<T> {
-    type Target = T::Response;
+impl<T> Deref for Response<T> {
+    type Target = T;
 
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
 
-impl<T: Widget> DerefMut for Response<T> {
+impl<T> DerefMut for Response<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }

--- a/crates/yakui-core/src/widget.rs
+++ b/crates/yakui-core/src/widget.rs
@@ -79,7 +79,7 @@ pub struct NavigateContext<'dom> {
 pub trait Widget: 'static + fmt::Debug {
     /// The props that this widget needs to be created or updated. Props define
     /// all of the values that a widget's user can specify every render.
-    type Props: Props;
+    type Props<'a>: Props;
 
     /// The type that the widget will return to the user when it is created or
     /// updated. This type should contain information like whether the widget
@@ -90,7 +90,7 @@ pub trait Widget: 'static + fmt::Debug {
     fn new() -> Self;
 
     /// Update the widget with new props.
-    fn update(&mut self, props: Self::Props) -> Self::Response;
+    fn update(&mut self, props: Self::Props<'_>) -> Self::Response;
 
     /// Returns whether this widget should grow to fill a flexible layout, and
     /// if so, what weight should be applied to it if other widgets also want to

--- a/crates/yakui-core/tests/regression.rs
+++ b/crates/yakui-core/tests/regression.rs
@@ -11,14 +11,14 @@ use yakui_core::Yakui;
 struct TestWidget;
 
 impl Widget for TestWidget {
-    type Props = ();
+    type Props<'a> = ();
     type Response = ();
 
     fn new() -> Self {
         Self
     }
 
-    fn update(&mut self, _props: Self::Props) -> Self::Response {}
+    fn update(&mut self, _props: Self::Props<'_>) -> Self::Response {}
 }
 
 /// https://github.com/LPGhatguy/yakui/issues/69
@@ -51,7 +51,7 @@ struct KeyboardWidget {
 }
 
 impl Widget for KeyboardWidget {
-    type Props = ();
+    type Props<'a> = ();
     type Response = Rc<AtomicUsize>;
 
     fn new() -> Self {
@@ -60,7 +60,7 @@ impl Widget for KeyboardWidget {
         }
     }
 
-    fn update(&mut self, _props: Self::Props) -> Self::Response {
+    fn update(&mut self, _props: Self::Props<'_>) -> Self::Response {
         self.count.clone()
     }
 

--- a/crates/yakui-widgets/src/shorthand.rs
+++ b/crates/yakui-widgets/src/shorthand.rs
@@ -10,41 +10,42 @@ use yakui_core::widget::PaintContext;
 use yakui_core::{Alignment, ManagedTextureId, Response, TextureId};
 
 use crate::widgets::{
-    Align, AlignWidget, Button, ButtonWidget, Canvas, CanvasWidget, Checkbox, CheckboxWidget,
-    Circle, CircleWidget, ColoredBox, ColoredBoxWidget, ConstrainedBox, ConstrainedBoxWidget,
-    Draggable, DraggableWidget, Flexible, FlexibleWidget, Image, ImageWidget, List, ListWidget,
-    MaxWidth, MaxWidthWidget, NineSlice, NineSliceWidget, Offset, OffsetWidget, Opaque,
-    OpaqueWidget, Pad, PadWidget, Reflow, ReflowWidget, Scrollable, ScrollableWidget, Slider,
-    SliderWidget, State, StateWidget, Text, TextBox, TextBoxWidget, TextWidget,
+    Align, AlignResponse, Button, ButtonResponse, Canvas, CanvasResponse, Checkbox,
+    CheckboxResponse, Circle, CircleResponse, ColoredBox, ColoredBoxResponse, ConstrainedBox,
+    ConstrainedBoxResponse, Draggable, DraggableResponse, Flexible, FlexibleResponse, Image,
+    ImageResponse, List, ListResponse, MaxWidth, MaxWidthResponse, NineSlice, Offset,
+    OffsetResponse, Opaque, OpaqueResponse, Pad, PadResponse, Reflow, ReflowResponse, Scrollable,
+    ScrollableResponse, Slider, SliderResponse, State, StateResponse, Text, TextBox,
+    TextBoxResponse, TextResponse,
 };
 
 /// See [List].
-pub fn column<F: FnOnce()>(children: F) -> Response<ListWidget> {
+pub fn column<F: FnOnce()>(children: F) -> Response<ListResponse> {
     List::column().show(children)
 }
 
 /// See [List].
-pub fn row<F: FnOnce()>(children: F) -> Response<ListWidget> {
+pub fn row<F: FnOnce()>(children: F) -> Response<ListResponse> {
     List::row().show(children)
 }
 
 /// See [Align].
-pub fn center<F: FnOnce()>(children: F) -> Response<AlignWidget> {
+pub fn center<F: FnOnce()>(children: F) -> Response<AlignResponse> {
     Align::center().show(children)
 }
 
 /// See [Align].
-pub fn align<F: FnOnce()>(alignment: Alignment, children: F) -> Response<AlignWidget> {
+pub fn align<F: FnOnce()>(alignment: Alignment, children: F) -> Response<AlignResponse> {
     Align::new(alignment).show(children)
 }
 
 /// See [Button].
-pub fn button<S: Into<Cow<'static, str>>>(text: S) -> Response<ButtonWidget> {
+pub fn button<S: Into<Cow<'static, str>>>(text: S) -> Response<ButtonResponse> {
     Button::styled(text.into()).show()
 }
 
 /// See [ColoredCircle].
-pub fn colored_circle<S: Into<f32>>(color: Color, size: S) -> Response<CircleWidget> {
+pub fn colored_circle<S: Into<f32>>(color: Color, size: S) -> Response<CircleResponse> {
     let mut circle = Circle::new();
     circle.min_radius = size.into();
     circle.color = color;
@@ -52,17 +53,20 @@ pub fn colored_circle<S: Into<f32>>(color: Color, size: S) -> Response<CircleWid
 }
 
 /// See [ColoredBox].
-pub fn colored_box<S: Into<Vec2>>(color: Color, size: S) -> Response<ColoredBoxWidget> {
+pub fn colored_box<S: Into<Vec2>>(color: Color, size: S) -> Response<ColoredBoxResponse> {
     ColoredBox::sized(color, size.into()).show()
 }
 
 /// See [ColoredBox].
-pub fn colored_box_container<F: FnOnce()>(color: Color, children: F) -> Response<ColoredBoxWidget> {
+pub fn colored_box_container<F: FnOnce()>(
+    color: Color,
+    children: F,
+) -> Response<ColoredBoxResponse> {
     ColoredBox::container(color).show_children(children)
 }
 
 /// See [Image].
-pub fn image<I, S>(image: I, size: S) -> Response<ImageWidget>
+pub fn image<I, S>(image: I, size: S) -> Response<ImageResponse>
 where
     I: Into<TextureId>,
     S: Into<Vec2>,
@@ -71,32 +75,32 @@ where
 }
 
 /// See [Pad].
-pub fn pad<F: FnOnce()>(padding: Pad, children: F) -> Response<PadWidget> {
+pub fn pad<F: FnOnce()>(padding: Pad, children: F) -> Response<PadResponse> {
     padding.show(children)
 }
 
 /// See [Text].
-pub fn text<S: Into<Cow<'static, str>>>(size: f32, text: S) -> Response<TextWidget> {
+pub fn text<S: Into<Cow<'static, str>>>(size: f32, text: S) -> Response<TextResponse> {
     Text::new(size, text.into()).show()
 }
 
 /// See [Text].
-pub fn label<S: Into<Cow<'static, str>>>(text: S) -> Response<TextWidget> {
+pub fn label<S: Into<Cow<'static, str>>>(text: S) -> Response<TextResponse> {
     Text::label(text.into()).show()
 }
 
 /// See [TextBox].
-pub fn textbox<S: Into<String>>(text: S) -> Response<TextBoxWidget> {
+pub fn textbox<S: Into<String>>(text: S) -> Response<TextBoxResponse> {
     TextBox::new(text.into()).show()
 }
 
 /// See [Flexible].
-pub fn flexible<F: FnOnce()>(flex: u32, children: F) -> Response<FlexibleWidget> {
+pub fn flexible<F: FnOnce()>(flex: u32, children: F) -> Response<FlexibleResponse> {
     Flexible::new(flex).show(children)
 }
 
 /// See [Flexible].
-pub fn expanded<F: FnOnce()>(children: F) -> Response<FlexibleWidget> {
+pub fn expanded<F: FnOnce()>(children: F) -> Response<FlexibleResponse> {
     Flexible::expanded().show(children)
 }
 
@@ -104,22 +108,22 @@ pub fn expanded<F: FnOnce()>(children: F) -> Response<FlexibleWidget> {
 pub fn constrained<F: FnOnce()>(
     constraints: Constraints,
     children: F,
-) -> Response<ConstrainedBoxWidget> {
+) -> Response<ConstrainedBoxResponse> {
     ConstrainedBox::new(constraints).show(children)
 }
 
 /// See [Checkbox].
-pub fn checkbox(checked: bool) -> Response<CheckboxWidget> {
+pub fn checkbox(checked: bool) -> Response<CheckboxResponse> {
     Checkbox::new(checked).show()
 }
 
 /// See [Offset].
-pub fn offset<F: FnOnce()>(offset: Vec2, children: F) -> Response<OffsetWidget> {
+pub fn offset<F: FnOnce()>(offset: Vec2, children: F) -> Response<OffsetResponse> {
     Offset::new(offset).show(children)
 }
 
 /// See [Draggable].
-pub fn draggable<F: FnOnce()>(children: F) -> Response<DraggableWidget> {
+pub fn draggable<F: FnOnce()>(children: F) -> Response<DraggableResponse> {
     Draggable::new().show(children)
 }
 
@@ -129,41 +133,45 @@ pub fn nineslice(
     margins: Pad,
     scale: f32,
     children: impl FnOnce(),
-) -> Response<NineSliceWidget> {
+) -> Response<()> {
     NineSlice::new(texture, margins, scale).show(children)
 }
 
 /// See [Scrollable].
-pub fn scroll_vertical(children: impl FnOnce()) -> Response<ScrollableWidget> {
+pub fn scroll_vertical(children: impl FnOnce()) -> Response<ScrollableResponse> {
     Scrollable::vertical().show(children)
 }
 
 /// See [Slider].
-pub fn slider(value: f64, min: f64, max: f64) -> Response<SliderWidget> {
+pub fn slider(value: f64, min: f64, max: f64) -> Response<SliderResponse> {
     Slider::new(value, min, max).show()
 }
 
 /// See [Reflow].
-pub fn reflow(anchor: Alignment, offset: Dim2, children: impl FnOnce()) -> Response<ReflowWidget> {
+pub fn reflow(
+    anchor: Alignment,
+    offset: Dim2,
+    children: impl FnOnce(),
+) -> Response<ReflowResponse> {
     Reflow::new(anchor, offset).show(children)
 }
 
 /// See [Opaque].
-pub fn opaque(children: impl FnOnce()) -> Response<OpaqueWidget> {
+pub fn opaque(children: impl FnOnce()) -> Response<OpaqueResponse> {
     Opaque::new().show(children)
 }
 
 /// See [Canvas].
-pub fn canvas(paint: impl Fn(&mut PaintContext<'_>) + 'static) -> Response<CanvasWidget> {
+pub fn canvas(paint: impl Fn(&mut PaintContext<'_>) + 'static) -> Response<CanvasResponse> {
     Canvas::new(paint).show()
 }
 
 /// See [MaxWidth].
-pub fn max_width(max_width: f32, children: impl FnOnce()) -> Response<MaxWidthWidget> {
+pub fn max_width(max_width: f32, children: impl FnOnce()) -> Response<MaxWidthResponse> {
     MaxWidth::new(max_width).show(children)
 }
 
-pub fn use_state<F, T: 'static>(default: F) -> Response<StateWidget<T>>
+pub fn use_state<F, T: 'static>(default: F) -> Response<StateResponse<T>>
 where
     F: FnOnce() -> T + 'static,
 {

--- a/crates/yakui-widgets/src/util.rs
+++ b/crates/yakui-widgets/src/util.rs
@@ -3,7 +3,7 @@ use yakui_core::widget::Widget;
 use yakui_core::Response;
 
 /// Show a widget with the given children and props.
-pub fn widget_children<T, F>(children: F, props: T::Props) -> Response<T::Response>
+pub fn widget_children<T, F>(children: F, props: T::Props<'_>) -> Response<T::Response>
 where
     T: Widget,
     F: FnOnce(),
@@ -16,7 +16,7 @@ where
 }
 
 /// Show a widget with the given props.
-pub fn widget<T>(props: T::Props) -> Response<T::Response>
+pub fn widget<T>(props: T::Props<'_>) -> Response<T::Response>
 where
     T: Widget,
 {

--- a/crates/yakui-widgets/src/util.rs
+++ b/crates/yakui-widgets/src/util.rs
@@ -3,7 +3,7 @@ use yakui_core::widget::Widget;
 use yakui_core::Response;
 
 /// Show a widget with the given children and props.
-pub fn widget_children<T, F>(children: F, props: T::Props) -> Response<T>
+pub fn widget_children<T, F>(children: F, props: T::Props) -> Response<T::Response>
 where
     T: Widget,
     F: FnOnce(),
@@ -16,7 +16,7 @@ where
 }
 
 /// Show a widget with the given props.
-pub fn widget<T>(props: T::Props) -> Response<T>
+pub fn widget<T>(props: T::Props) -> Response<T::Response>
 where
     T: Widget,
 {

--- a/crates/yakui-widgets/src/widgets/align.rs
+++ b/crates/yakui-widgets/src/widgets/align.rs
@@ -49,7 +49,7 @@ impl Align {
         }
     }
 
-    pub fn show<F: FnOnce()>(self, children: F) -> Response<AlignWidget> {
+    pub fn show<F: FnOnce()>(self, children: F) -> Response<AlignResponse> {
         widget_children::<AlignWidget, F>(children, self)
     }
 }

--- a/crates/yakui-widgets/src/widgets/align.rs
+++ b/crates/yakui-widgets/src/widgets/align.rs
@@ -62,7 +62,7 @@ pub struct AlignWidget {
 pub type AlignResponse = ();
 
 impl Widget for AlignWidget {
-    type Props = Align;
+    type Props<'a> = Align;
     type Response = AlignResponse;
 
     fn new() -> Self {
@@ -71,7 +71,7 @@ impl Widget for AlignWidget {
         }
     }
 
-    fn update(&mut self, props: Self::Props) -> Self::Response {
+    fn update(&mut self, props: Self::Props<'_>) -> Self::Response {
         self.props = props;
     }
 

--- a/crates/yakui-widgets/src/widgets/button.rs
+++ b/crates/yakui-widgets/src/widgets/button.rs
@@ -98,7 +98,7 @@ impl Button {
         }
     }
 
-    pub fn show(self) -> Response<ButtonWidget> {
+    pub fn show(self) -> Response<ButtonResponse> {
         widget::<ButtonWidget>(self)
     }
 }

--- a/crates/yakui-widgets/src/widgets/button.rs
+++ b/crates/yakui-widgets/src/widgets/button.rs
@@ -118,7 +118,7 @@ pub struct ButtonResponse {
 }
 
 impl Widget for ButtonWidget {
-    type Props = Button;
+    type Props<'a> = Button;
     type Response = ButtonResponse;
 
     fn new() -> Self {
@@ -130,7 +130,7 @@ impl Widget for ButtonWidget {
         }
     }
 
-    fn update(&mut self, props: Self::Props) -> Self::Response {
+    fn update(&mut self, props: Self::Props<'_>) -> Self::Response {
         self.props = props;
 
         let mut color = self.props.style.fill;

--- a/crates/yakui-widgets/src/widgets/canvas.rs
+++ b/crates/yakui-widgets/src/widgets/canvas.rs
@@ -40,7 +40,7 @@ pub struct CanvasWidget {
 pub type CanvasResponse = ();
 
 impl Widget for CanvasWidget {
-    type Props = Canvas;
+    type Props<'a> = Canvas;
     type Response = CanvasResponse;
 
     fn new() -> Self {
@@ -51,7 +51,7 @@ impl Widget for CanvasWidget {
         }
     }
 
-    fn update(&mut self, props: Self::Props) -> Self::Response {
+    fn update(&mut self, props: Self::Props<'_>) -> Self::Response {
         self.props = props;
     }
 

--- a/crates/yakui-widgets/src/widgets/canvas.rs
+++ b/crates/yakui-widgets/src/widgets/canvas.rs
@@ -23,11 +23,11 @@ impl Canvas {
         }
     }
 
-    pub fn show(self) -> Response<CanvasWidget> {
+    pub fn show(self) -> Response<CanvasResponse> {
         widget::<CanvasWidget>(self)
     }
 
-    pub fn show_children<F: FnOnce()>(self, children: F) -> Response<CanvasWidget> {
+    pub fn show_children<F: FnOnce()>(self, children: F) -> Response<CanvasResponse> {
         widget_children::<CanvasWidget, F>(children, self)
     }
 }

--- a/crates/yakui-widgets/src/widgets/checkbox.rs
+++ b/crates/yakui-widgets/src/widgets/checkbox.rs
@@ -54,7 +54,7 @@ pub struct CheckboxResponse {
 }
 
 impl Widget for CheckboxWidget {
-    type Props = Checkbox;
+    type Props<'a> = Checkbox;
     type Response = CheckboxResponse;
 
     fn new() -> Self {
@@ -66,7 +66,7 @@ impl Widget for CheckboxWidget {
         }
     }
 
-    fn update(&mut self, props: Self::Props) -> Self::Response {
+    fn update(&mut self, props: Self::Props<'_>) -> Self::Response {
         self.props = props;
 
         let mut checked = self.props.checked;

--- a/crates/yakui-widgets/src/widgets/checkbox.rs
+++ b/crates/yakui-widgets/src/widgets/checkbox.rs
@@ -34,7 +34,7 @@ impl Checkbox {
         Self { checked }
     }
 
-    pub fn show(self) -> Response<CheckboxWidget> {
+    pub fn show(self) -> Response<CheckboxResponse> {
         crate::util::widget::<CheckboxWidget>(self)
     }
 }

--- a/crates/yakui-widgets/src/widgets/circle.rs
+++ b/crates/yakui-widgets/src/widgets/circle.rs
@@ -42,7 +42,7 @@ pub struct CircleWidget {
 pub type CircleResponse = ();
 
 impl Widget for CircleWidget {
-    type Props = Circle;
+    type Props<'a> = Circle;
     type Response = CircleResponse;
 
     fn new() -> Self {
@@ -51,7 +51,7 @@ impl Widget for CircleWidget {
         }
     }
 
-    fn update(&mut self, props: Self::Props) -> Self::Response {
+    fn update(&mut self, props: Self::Props<'_>) -> Self::Response {
         self.props = props;
     }
 

--- a/crates/yakui-widgets/src/widgets/circle.rs
+++ b/crates/yakui-widgets/src/widgets/circle.rs
@@ -25,11 +25,11 @@ impl Circle {
         }
     }
 
-    pub fn show(self) -> Response<CircleWidget> {
+    pub fn show(self) -> Response<CircleResponse> {
         widget::<CircleWidget>(self)
     }
 
-    pub fn show_children<F: FnOnce()>(self, children: F) -> Response<CircleWidget> {
+    pub fn show_children<F: FnOnce()>(self, children: F) -> Response<CircleResponse> {
         widget_children::<CircleWidget, F>(children, self)
     }
 }

--- a/crates/yakui-widgets/src/widgets/colored_box.rs
+++ b/crates/yakui-widgets/src/widgets/colored_box.rs
@@ -56,7 +56,7 @@ pub struct ColoredBoxWidget {
 pub type ColoredBoxResponse = ();
 
 impl Widget for ColoredBoxWidget {
-    type Props = ColoredBox;
+    type Props<'a> = ColoredBox;
     type Response = ColoredBoxResponse;
 
     fn new() -> Self {
@@ -65,7 +65,7 @@ impl Widget for ColoredBoxWidget {
         }
     }
 
-    fn update(&mut self, props: Self::Props) -> Self::Response {
+    fn update(&mut self, props: Self::Props<'_>) -> Self::Response {
         self.props = props;
     }
 

--- a/crates/yakui-widgets/src/widgets/colored_box.rs
+++ b/crates/yakui-widgets/src/widgets/colored_box.rs
@@ -39,11 +39,11 @@ impl ColoredBox {
         }
     }
 
-    pub fn show(self) -> Response<ColoredBoxWidget> {
+    pub fn show(self) -> Response<ColoredBoxResponse> {
         widget::<ColoredBoxWidget>(self)
     }
 
-    pub fn show_children<F: FnOnce()>(self, children: F) -> Response<ColoredBoxWidget> {
+    pub fn show_children<F: FnOnce()>(self, children: F) -> Response<ColoredBoxResponse> {
         widget_children::<ColoredBoxWidget, F>(children, self)
     }
 }

--- a/crates/yakui-widgets/src/widgets/constrained_box.rs
+++ b/crates/yakui-widgets/src/widgets/constrained_box.rs
@@ -33,7 +33,7 @@ pub struct ConstrainedBoxWidget {
 pub type ConstrainedBoxResponse = ();
 
 impl Widget for ConstrainedBoxWidget {
-    type Props = ConstrainedBox;
+    type Props<'a> = ConstrainedBox;
     type Response = ConstrainedBoxResponse;
 
     fn new() -> Self {
@@ -45,7 +45,7 @@ impl Widget for ConstrainedBoxWidget {
         }
     }
 
-    fn update(&mut self, props: Self::Props) -> Self::Response {
+    fn update(&mut self, props: Self::Props<'_>) -> Self::Response {
         self.props = props;
     }
 

--- a/crates/yakui-widgets/src/widgets/constrained_box.rs
+++ b/crates/yakui-widgets/src/widgets/constrained_box.rs
@@ -20,7 +20,7 @@ impl ConstrainedBox {
         Self { constraints }
     }
 
-    pub fn show<F: FnOnce()>(self, children: F) -> Response<ConstrainedBoxWidget> {
+    pub fn show<F: FnOnce()>(self, children: F) -> Response<ConstrainedBoxResponse> {
         widget_children::<ConstrainedBoxWidget, F>(children, self)
     }
 }

--- a/crates/yakui-widgets/src/widgets/cutout.rs
+++ b/crates/yakui-widgets/src/widgets/cutout.rs
@@ -33,11 +33,11 @@ impl CutOut {
         }
     }
 
-    pub fn show(self) -> Response<CutOutWidget> {
+    pub fn show(self) -> Response<CutOutResponse> {
         widget::<CutOutWidget>(self)
     }
 
-    pub fn show_children<F: FnOnce()>(self, children: F) -> Response<CutOutWidget> {
+    pub fn show_children<F: FnOnce()>(self, children: F) -> Response<CutOutResponse> {
         widget_children::<CutOutWidget, F>(children, self)
     }
 }

--- a/crates/yakui-widgets/src/widgets/cutout.rs
+++ b/crates/yakui-widgets/src/widgets/cutout.rs
@@ -50,7 +50,7 @@ pub struct CutOutWidget {
 pub type CutOutResponse = ();
 
 impl Widget for CutOutWidget {
-    type Props = CutOut;
+    type Props<'a> = CutOut;
     type Response = CutOutResponse;
 
     fn new() -> Self {
@@ -64,7 +64,7 @@ impl Widget for CutOutWidget {
         }
     }
 
-    fn update(&mut self, props: Self::Props) -> Self::Response {
+    fn update(&mut self, props: Self::Props<'_>) -> Self::Response {
         self.props = props;
     }
 

--- a/crates/yakui-widgets/src/widgets/draggable.rs
+++ b/crates/yakui-widgets/src/widgets/draggable.rs
@@ -45,14 +45,14 @@ pub struct Dragging {
 }
 
 impl Widget for DraggableWidget {
-    type Props = Draggable;
+    type Props<'a> = Draggable;
     type Response = DraggableResponse;
 
     fn new() -> Self {
         Self { current_drag: None }
     }
 
-    fn update(&mut self, _props: Self::Props) -> Self::Response {
+    fn update(&mut self, _props: Self::Props<'_>) -> Self::Response {
         let dragging = self.current_drag.as_ref().map(|drag| Dragging {
             start: drag.start_position,
             current: drag.mouse_position + drag.offset_from_mouse,

--- a/crates/yakui-widgets/src/widgets/draggable.rs
+++ b/crates/yakui-widgets/src/widgets/draggable.rs
@@ -15,7 +15,7 @@ impl Draggable {
         Draggable {}
     }
 
-    pub fn show<F: FnOnce()>(self, children: F) -> Response<DraggableWidget> {
+    pub fn show<F: FnOnce()>(self, children: F) -> Response<DraggableResponse> {
         widget_children::<DraggableWidget, F>(children, self)
     }
 }

--- a/crates/yakui-widgets/src/widgets/flexible.rs
+++ b/crates/yakui-widgets/src/widgets/flexible.rs
@@ -43,7 +43,7 @@ impl Flexible {
         }
     }
 
-    pub fn show<F: FnOnce()>(self, children: F) -> Response<FlexibleWidget> {
+    pub fn show<F: FnOnce()>(self, children: F) -> Response<FlexibleResponse> {
         widget_children::<FlexibleWidget, F>(children, self)
     }
 }

--- a/crates/yakui-widgets/src/widgets/flexible.rs
+++ b/crates/yakui-widgets/src/widgets/flexible.rs
@@ -56,7 +56,7 @@ pub struct FlexibleWidget {
 pub type FlexibleResponse = ();
 
 impl Widget for FlexibleWidget {
-    type Props = Flexible;
+    type Props<'a> = Flexible;
     type Response = FlexibleResponse;
 
     fn new() -> Self {
@@ -65,7 +65,7 @@ impl Widget for FlexibleWidget {
         }
     }
 
-    fn update(&mut self, props: Self::Props) -> Self::Response {
+    fn update(&mut self, props: Self::Props<'_>) -> Self::Response {
         self.props = props;
     }
 

--- a/crates/yakui-widgets/src/widgets/image.rs
+++ b/crates/yakui-widgets/src/widgets/image.rs
@@ -41,7 +41,7 @@ pub struct ImageWidget {
 pub type ImageResponse = ();
 
 impl Widget for ImageWidget {
-    type Props = Image;
+    type Props<'a> = Image;
     type Response = ImageResponse;
 
     fn new() -> Self {
@@ -53,7 +53,7 @@ impl Widget for ImageWidget {
         }
     }
 
-    fn update(&mut self, props: Self::Props) -> Self::Response {
+    fn update(&mut self, props: Self::Props<'_>) -> Self::Response {
         self.props = props;
     }
 

--- a/crates/yakui-widgets/src/widgets/image.rs
+++ b/crates/yakui-widgets/src/widgets/image.rs
@@ -28,7 +28,7 @@ impl Image {
         }
     }
 
-    pub fn show(self) -> Response<ImageWidget> {
+    pub fn show(self) -> Response<ImageResponse> {
         widget::<ImageWidget>(self)
     }
 }

--- a/crates/yakui-widgets/src/widgets/layer.rs
+++ b/crates/yakui-widgets/src/widgets/layer.rs
@@ -33,14 +33,14 @@ pub struct LayerWidget {
 pub type LayerResponse = ();
 
 impl Widget for LayerWidget {
-    type Props = Layer;
+    type Props<'a> = Layer;
     type Response = LayerResponse;
 
     fn new() -> Self {
         Self { props: Layer {} }
     }
 
-    fn update(&mut self, props: Self::Props) -> Self::Response {
+    fn update(&mut self, props: Self::Props<'_>) -> Self::Response {
         self.props = props;
     }
 

--- a/crates/yakui-widgets/src/widgets/layer.rs
+++ b/crates/yakui-widgets/src/widgets/layer.rs
@@ -20,7 +20,7 @@ impl Layer {
         Self {}
     }
 
-    pub fn show<F: FnOnce()>(self, children: F) -> Response<LayerWidget> {
+    pub fn show<F: FnOnce()>(self, children: F) -> Response<LayerResponse> {
         widget_children::<LayerWidget, F>(children, self)
     }
 }

--- a/crates/yakui-widgets/src/widgets/list.rs
+++ b/crates/yakui-widgets/src/widgets/list.rs
@@ -56,7 +56,7 @@ impl List {
         Self::new(Direction::Right)
     }
 
-    pub fn show<F: FnOnce()>(self, children: F) -> Response<ListWidget> {
+    pub fn show<F: FnOnce()>(self, children: F) -> Response<ListResponse> {
         widget_children::<ListWidget, F>(children, self)
     }
 }

--- a/crates/yakui-widgets/src/widgets/list.rs
+++ b/crates/yakui-widgets/src/widgets/list.rs
@@ -69,14 +69,14 @@ pub struct ListWidget {
 pub type ListResponse = ();
 
 impl Widget for ListWidget {
-    type Props = List;
+    type Props<'a> = List;
     type Response = ListResponse;
 
     fn new() -> Self {
         Self { props: List::row() }
     }
 
-    fn update(&mut self, props: Self::Props) -> Self::Response {
+    fn update(&mut self, props: Self::Props<'_>) -> Self::Response {
         self.props = props;
     }
 

--- a/crates/yakui-widgets/src/widgets/max_width.rs
+++ b/crates/yakui-widgets/src/widgets/max_width.rs
@@ -22,7 +22,7 @@ impl MaxWidth {
         Self { max_width }
     }
 
-    pub fn show<F: FnOnce()>(self, children: F) -> Response<MaxWidthWidget> {
+    pub fn show<F: FnOnce()>(self, children: F) -> Response<MaxWidthResponse> {
         widget_children::<MaxWidthWidget, F>(children, self)
     }
 }

--- a/crates/yakui-widgets/src/widgets/max_width.rs
+++ b/crates/yakui-widgets/src/widgets/max_width.rs
@@ -35,7 +35,7 @@ pub struct MaxWidthWidget {
 pub type MaxWidthResponse = ();
 
 impl Widget for MaxWidthWidget {
-    type Props = MaxWidth;
+    type Props<'a> = MaxWidth;
     type Response = MaxWidthResponse;
 
     fn new() -> Self {
@@ -46,7 +46,7 @@ impl Widget for MaxWidthWidget {
         }
     }
 
-    fn update(&mut self, props: Self::Props) -> Self::Response {
+    fn update(&mut self, props: Self::Props<'_>) -> Self::Response {
         self.props = props;
     }
 

--- a/crates/yakui-widgets/src/widgets/nineslice.rs
+++ b/crates/yakui-widgets/src/widgets/nineslice.rs
@@ -50,14 +50,14 @@ pub struct NineSliceWidget {
 }
 
 impl Widget for NineSliceWidget {
-    type Props = NineSlice;
+    type Props<'a> = NineSlice;
     type Response = ();
 
     fn new() -> Self {
         Self { props: None }
     }
 
-    fn update(&mut self, props: Self::Props) -> Self::Response {
+    fn update(&mut self, props: Self::Props<'_>) -> Self::Response {
         self.props = Some(props);
     }
 

--- a/crates/yakui-widgets/src/widgets/nineslice.rs
+++ b/crates/yakui-widgets/src/widgets/nineslice.rs
@@ -25,7 +25,7 @@ impl NineSlice {
         }
     }
 
-    pub fn show(self, children: impl FnOnce()) -> Response<NineSliceWidget> {
+    pub fn show(self, children: impl FnOnce()) -> Response<()> {
         let scaled_margins = {
             let mut m = self.margins;
             m.left *= self.scale;

--- a/crates/yakui-widgets/src/widgets/offset.rs
+++ b/crates/yakui-widgets/src/widgets/offset.rs
@@ -31,7 +31,7 @@ pub struct OffsetWidget {
 pub type OffsetResponse = ();
 
 impl Widget for OffsetWidget {
-    type Props = Offset;
+    type Props<'a> = Offset;
     type Response = OffsetResponse;
 
     fn new() -> Self {
@@ -40,7 +40,7 @@ impl Widget for OffsetWidget {
         }
     }
 
-    fn update(&mut self, props: Self::Props) -> Self::Response {
+    fn update(&mut self, props: Self::Props<'_>) -> Self::Response {
         self.props = props;
     }
 

--- a/crates/yakui-widgets/src/widgets/offset.rs
+++ b/crates/yakui-widgets/src/widgets/offset.rs
@@ -18,7 +18,7 @@ impl Offset {
         Self { offset }
     }
 
-    pub fn show<F: FnOnce()>(self, children: F) -> Response<OffsetWidget> {
+    pub fn show<F: FnOnce()>(self, children: F) -> Response<OffsetResponse> {
         widget_children::<OffsetWidget, F>(children, self)
     }
 }

--- a/crates/yakui-widgets/src/widgets/opaque.rs
+++ b/crates/yakui-widgets/src/widgets/opaque.rs
@@ -18,7 +18,7 @@ impl Opaque {
         Self {}
     }
 
-    pub fn show<F: FnOnce()>(self, children: F) -> Response<OpaqueWidget> {
+    pub fn show<F: FnOnce()>(self, children: F) -> Response<OpaqueResponse> {
         widget_children::<OpaqueWidget, F>(children, self)
     }
 }

--- a/crates/yakui-widgets/src/widgets/opaque.rs
+++ b/crates/yakui-widgets/src/widgets/opaque.rs
@@ -31,14 +31,14 @@ pub struct OpaqueWidget {
 pub type OpaqueResponse = ();
 
 impl Widget for OpaqueWidget {
-    type Props = Opaque;
+    type Props<'a> = Opaque;
     type Response = OpaqueResponse;
 
     fn new() -> Self {
         Self { props: Opaque {} }
     }
 
-    fn update(&mut self, props: Self::Props) -> Self::Response {
+    fn update(&mut self, props: Self::Props<'_>) -> Self::Response {
         self.props = props;
     }
 

--- a/crates/yakui-widgets/src/widgets/pad.rs
+++ b/crates/yakui-widgets/src/widgets/pad.rs
@@ -61,7 +61,7 @@ impl Pad {
         Vec2::new(self.left, self.top)
     }
 
-    pub fn show<F: FnOnce()>(self, children: F) -> Response<PadWidget> {
+    pub fn show<F: FnOnce()>(self, children: F) -> Response<PadResponse> {
         widget_children::<PadWidget, F>(children, self)
     }
 }

--- a/crates/yakui-widgets/src/widgets/pad.rs
+++ b/crates/yakui-widgets/src/widgets/pad.rs
@@ -74,14 +74,14 @@ pub struct PadWidget {
 pub type PadResponse = ();
 
 impl Widget for PadWidget {
-    type Props = Pad;
+    type Props<'a> = Pad;
     type Response = PadResponse;
 
     fn new() -> Self {
         Self { props: Pad::ZERO }
     }
 
-    fn update(&mut self, props: Self::Props) -> Self::Response {
+    fn update(&mut self, props: Self::Props<'_>) -> Self::Response {
         self.props = props;
     }
 

--- a/crates/yakui-widgets/src/widgets/panel.rs
+++ b/crates/yakui-widgets/src/widgets/panel.rs
@@ -55,7 +55,7 @@ pub struct PanelWidget {
 pub type PanelResponse = ();
 
 impl Widget for PanelWidget {
-    type Props = Panel;
+    type Props<'a> = Panel;
     type Response = PanelResponse;
 
     fn new() -> Self {
@@ -65,7 +65,7 @@ impl Widget for PanelWidget {
         }
     }
 
-    fn update(&mut self, props: Self::Props) -> Self::Response {
+    fn update(&mut self, props: Self::Props<'_>) -> Self::Response {
         self.props = props;
     }
 

--- a/crates/yakui-widgets/src/widgets/panel.rs
+++ b/crates/yakui-widgets/src/widgets/panel.rs
@@ -41,7 +41,7 @@ impl Panel {
         }
     }
 
-    pub fn show<F: FnOnce()>(self, children: F) -> Response<PanelWidget> {
+    pub fn show<F: FnOnce()>(self, children: F) -> Response<PanelResponse> {
         widget_children::<PanelWidget, F>(children, self)
     }
 }

--- a/crates/yakui-widgets/src/widgets/reflow.rs
+++ b/crates/yakui-widgets/src/widgets/reflow.rs
@@ -20,7 +20,7 @@ impl Reflow {
         Self { anchor, offset }
     }
 
-    pub fn show<F: FnOnce()>(self, children: F) -> Response<ReflowWidget> {
+    pub fn show<F: FnOnce()>(self, children: F) -> Response<ReflowResponse> {
         widget_children::<ReflowWidget, F>(children, self)
     }
 }

--- a/crates/yakui-widgets/src/widgets/reflow.rs
+++ b/crates/yakui-widgets/src/widgets/reflow.rs
@@ -33,7 +33,7 @@ pub struct ReflowWidget {
 pub type ReflowResponse = ();
 
 impl Widget for ReflowWidget {
-    type Props = Reflow;
+    type Props<'a> = Reflow;
     type Response = ReflowResponse;
 
     fn new() -> Self {
@@ -45,7 +45,7 @@ impl Widget for ReflowWidget {
         }
     }
 
-    fn update(&mut self, props: Self::Props) -> Self::Response {
+    fn update(&mut self, props: Self::Props<'_>) -> Self::Response {
         self.props = props;
     }
 

--- a/crates/yakui-widgets/src/widgets/render_text.rs
+++ b/crates/yakui-widgets/src/widgets/render_text.rs
@@ -55,7 +55,7 @@ pub struct RenderTextWidget {
 pub type RenderTextResponse = ();
 
 impl Widget for RenderTextWidget {
-    type Props = RenderText;
+    type Props<'a> = RenderText;
     type Response = RenderTextResponse;
 
     fn new() -> Self {
@@ -67,7 +67,7 @@ impl Widget for RenderTextWidget {
         }
     }
 
-    fn update(&mut self, props: Self::Props) -> Self::Response {
+    fn update(&mut self, props: Self::Props<'_>) -> Self::Response {
         self.props = props;
     }
 

--- a/crates/yakui-widgets/src/widgets/render_text.rs
+++ b/crates/yakui-widgets/src/widgets/render_text.rs
@@ -42,7 +42,7 @@ impl RenderText {
         }
     }
 
-    pub fn show(self) -> Response<RenderTextWidget> {
+    pub fn show(self) -> Response<RenderTextResponse> {
         widget::<RenderTextWidget>(self)
     }
 }

--- a/crates/yakui-widgets/src/widgets/render_textbox.rs
+++ b/crates/yakui-widgets/src/widgets/render_textbox.rs
@@ -38,7 +38,7 @@ impl RenderTextBox {
         }
     }
 
-    pub fn show(self) -> Response<RenderTextBoxWidget> {
+    pub fn show(self) -> Response<RenderTextBoxResponse> {
         widget::<RenderTextBoxWidget>(self)
     }
 }

--- a/crates/yakui-widgets/src/widgets/render_textbox.rs
+++ b/crates/yakui-widgets/src/widgets/render_textbox.rs
@@ -56,7 +56,7 @@ pub struct RenderTextBoxResponse {
 }
 
 impl Widget for RenderTextBoxWidget {
-    type Props = RenderTextBox;
+    type Props<'a> = RenderTextBox;
     type Response = RenderTextBoxResponse;
 
     fn new() -> Self {
@@ -69,7 +69,7 @@ impl Widget for RenderTextBoxWidget {
         }
     }
 
-    fn update(&mut self, props: Self::Props) -> Self::Response {
+    fn update(&mut self, props: Self::Props<'_>) -> Self::Response {
         self.props = props;
         RenderTextBoxResponse {
             layout: self.layout.clone(),

--- a/crates/yakui-widgets/src/widgets/round_rect.rs
+++ b/crates/yakui-widgets/src/widgets/round_rect.rs
@@ -27,11 +27,11 @@ impl RoundRect {
         }
     }
 
-    pub fn show(self) -> Response<RoundRectWidget> {
+    pub fn show(self) -> Response<RoundRectResponse> {
         widget::<RoundRectWidget>(self)
     }
 
-    pub fn show_children<F: FnOnce()>(self, children: F) -> Response<RoundRectWidget> {
+    pub fn show_children<F: FnOnce()>(self, children: F) -> Response<RoundRectResponse> {
         widget_children::<RoundRectWidget, F>(children, self)
     }
 }

--- a/crates/yakui-widgets/src/widgets/round_rect.rs
+++ b/crates/yakui-widgets/src/widgets/round_rect.rs
@@ -44,7 +44,7 @@ pub struct RoundRectWidget {
 pub type RoundRectResponse = ();
 
 impl Widget for RoundRectWidget {
-    type Props = RoundRect;
+    type Props<'a> = RoundRect;
     type Response = RoundRectResponse;
 
     fn new() -> Self {
@@ -53,7 +53,7 @@ impl Widget for RoundRectWidget {
         }
     }
 
-    fn update(&mut self, props: Self::Props) -> Self::Response {
+    fn update(&mut self, props: Self::Props<'_>) -> Self::Response {
         self.props = props;
     }
 

--- a/crates/yakui-widgets/src/widgets/scrollable.rs
+++ b/crates/yakui-widgets/src/widgets/scrollable.rs
@@ -45,7 +45,7 @@ pub struct ScrollableWidget {
 pub type ScrollableResponse = ();
 
 impl Widget for ScrollableWidget {
-    type Props = Scrollable;
+    type Props<'a> = Scrollable;
     type Response = ScrollableResponse;
 
     fn new() -> Self {
@@ -56,7 +56,7 @@ impl Widget for ScrollableWidget {
         }
     }
 
-    fn update(&mut self, props: Self::Props) -> Self::Response {
+    fn update(&mut self, props: Self::Props<'_>) -> Self::Response {
         self.props = props;
     }
 

--- a/crates/yakui-widgets/src/widgets/scrollable.rs
+++ b/crates/yakui-widgets/src/widgets/scrollable.rs
@@ -24,7 +24,7 @@ impl Scrollable {
         }
     }
 
-    pub fn show<F: FnOnce()>(self, children: F) -> Response<ScrollableWidget> {
+    pub fn show<F: FnOnce()>(self, children: F) -> Response<ScrollableResponse> {
         widget_children::<ScrollableWidget, F>(children, self)
     }
 }

--- a/crates/yakui-widgets/src/widgets/slider.rs
+++ b/crates/yakui-widgets/src/widgets/slider.rs
@@ -35,8 +35,8 @@ impl Slider {
         }
     }
 
-    pub fn show(self) -> Response<SliderWidget> {
-        util::widget(self)
+    pub fn show(self) -> Response<SliderResponse> {
+        util::widget::<SliderWidget>(self)
     }
 }
 

--- a/crates/yakui-widgets/src/widgets/slider.rs
+++ b/crates/yakui-widgets/src/widgets/slider.rs
@@ -53,7 +53,7 @@ pub struct SliderWidget {
 }
 
 impl Widget for SliderWidget {
-    type Props = Slider;
+    type Props<'a> = Slider;
     type Response = SliderResponse;
 
     fn new() -> Self {
@@ -63,7 +63,7 @@ impl Widget for SliderWidget {
         }
     }
 
-    fn update(&mut self, props: Self::Props) -> Self::Response {
+    fn update(&mut self, props: Self::Props<'_>) -> Self::Response {
         self.props = props;
 
         colored_box(TRACK_COLOR, [0.0, TRACK_HEIGHT]);

--- a/crates/yakui-widgets/src/widgets/state.rs
+++ b/crates/yakui-widgets/src/widgets/state.rs
@@ -69,14 +69,14 @@ pub struct StateWidget<T> {
 }
 
 impl<T: 'static> Widget for StateWidget<T> {
-    type Props = State<T>;
+    type Props<'a> = State<T>;
     type Response = StateResponse<T>;
 
     fn new() -> Self {
         Self { value: None }
     }
 
-    fn update(&mut self, props: Self::Props) -> Self::Response {
+    fn update(&mut self, props: Self::Props<'_>) -> Self::Response {
         let value = self
             .value
             .get_or_insert_with(|| Rc::new(RefCell::new((props.default)())))

--- a/crates/yakui-widgets/src/widgets/state.rs
+++ b/crates/yakui-widgets/src/widgets/state.rs
@@ -21,8 +21,8 @@ impl<T: 'static> State<T> {
         }
     }
 
-    pub fn show(self) -> Response<StateWidget<T>> {
-        util::widget(self)
+    pub fn show(self) -> Response<StateResponse<T>> {
+        util::widget::<StateWidget<T>>(self)
     }
 }
 

--- a/crates/yakui-widgets/src/widgets/text.rs
+++ b/crates/yakui-widgets/src/widgets/text.rs
@@ -68,7 +68,7 @@ pub struct TextWidget {
 pub type TextResponse = ();
 
 impl Widget for TextWidget {
-    type Props = Text;
+    type Props<'a> = Text;
     type Response = TextResponse;
 
     fn new() -> Self {
@@ -77,7 +77,7 @@ impl Widget for TextWidget {
         }
     }
 
-    fn update(&mut self, props: Self::Props) -> Self::Response {
+    fn update(&mut self, props: Self::Props<'_>) -> Self::Response {
         self.props = props;
 
         let mut render = RenderText::label(self.props.text.clone());

--- a/crates/yakui-widgets/src/widgets/text.rs
+++ b/crates/yakui-widgets/src/widgets/text.rs
@@ -55,7 +55,7 @@ impl Text {
         }
     }
 
-    pub fn show(self) -> Response<TextWidget> {
+    pub fn show(self) -> Response<TextResponse> {
         widget::<TextWidget>(self)
     }
 }

--- a/crates/yakui-widgets/src/widgets/textbox.rs
+++ b/crates/yakui-widgets/src/widgets/textbox.rs
@@ -45,7 +45,7 @@ impl TextBox {
         }
     }
 
-    pub fn show(self) -> Response<TextBoxWidget> {
+    pub fn show(self) -> Response<TextBoxResponse> {
         widget::<TextBoxWidget>(self)
     }
 }

--- a/crates/yakui-widgets/src/widgets/textbox.rs
+++ b/crates/yakui-widgets/src/widgets/textbox.rs
@@ -67,7 +67,7 @@ pub struct TextBoxResponse {
 }
 
 impl Widget for TextBoxWidget {
-    type Props = TextBox;
+    type Props<'a> = TextBox;
     type Response = TextBoxResponse;
 
     fn new() -> Self {
@@ -81,7 +81,7 @@ impl Widget for TextBoxWidget {
         }
     }
 
-    fn update(&mut self, props: Self::Props) -> Self::Response {
+    fn update(&mut self, props: Self::Props<'_>) -> Self::Response {
         self.props = props;
 
         let mut text = self.updated_text.as_ref().unwrap_or(&self.props.text);

--- a/crates/yakui-widgets/src/widgets/unconstrained_box.rs
+++ b/crates/yakui-widgets/src/widgets/unconstrained_box.rs
@@ -39,7 +39,7 @@ pub struct UnconstrainedBoxWidget {
 pub type UnconstrainedBoxResponse = ();
 
 impl Widget for UnconstrainedBoxWidget {
-    type Props = UnconstrainedBox;
+    type Props<'a> = UnconstrainedBox;
     type Response = UnconstrainedBoxResponse;
 
     fn new() -> Self {
@@ -48,7 +48,7 @@ impl Widget for UnconstrainedBoxWidget {
         }
     }
 
-    fn update(&mut self, props: Self::Props) -> Self::Response {
+    fn update(&mut self, props: Self::Props<'_>) -> Self::Response {
         self.props = props;
     }
 

--- a/crates/yakui-widgets/src/widgets/unconstrained_box.rs
+++ b/crates/yakui-widgets/src/widgets/unconstrained_box.rs
@@ -26,7 +26,7 @@ impl UnconstrainedBox {
         }
     }
 
-    pub fn show<F: FnOnce()>(self, children: F) -> Response<UnconstrainedBoxWidget> {
+    pub fn show<F: FnOnce()>(self, children: F) -> Response<UnconstrainedBoxResponse> {
         widget_children::<UnconstrainedBoxWidget, F>(children, self)
     }
 }

--- a/crates/yakui-widgets/src/widgets/window.rs
+++ b/crates/yakui-widgets/src/widgets/window.rs
@@ -40,7 +40,7 @@ pub struct WindowWidget {
 pub type WindowResponse = ();
 
 impl Widget for WindowWidget {
-    type Props = Window;
+    type Props<'a> = Window;
     type Response = WindowResponse;
 
     fn new() -> Self {
@@ -49,7 +49,7 @@ impl Widget for WindowWidget {
         }
     }
 
-    fn update(&mut self, props: Self::Props) -> Self::Response {
+    fn update(&mut self, props: Self::Props<'_>) -> Self::Response {
         self.props = props;
 
         crate::colored_box_container(colors::BACKGROUND_2, || {

--- a/crates/yakui-widgets/src/widgets/window.rs
+++ b/crates/yakui-widgets/src/widgets/window.rs
@@ -26,7 +26,7 @@ impl Window {
         }
     }
 
-    pub fn show<F: 'static + Fn()>(mut self, children: F) -> Response<WindowWidget> {
+    pub fn show<F: 'static + Fn()>(mut self, children: F) -> Response<WindowResponse> {
         self.children = Some(Box::new(children));
         widget::<WindowWidget>(self)
     }


### PR DESCRIPTION
Allows widgets to e.g. offer small, lightweight views into expensive-to-clone data, or borrow trait objects without boxing.