### PR TITLE
Convert pixel scroll deltas into logical units

### DIFF
--- a/crates/yakui-winit/src/lib.rs
+++ b/crates/yakui-winit/src/lib.rs
@@ -139,6 +139,7 @@ impl YakuiWinit {
                     MouseScrollDelta::LineDelta(x, y) => Vec2::new(x, y) * LINE_HEIGHT,
                     MouseScrollDelta::PixelDelta(offset) => {
                         Vec2::new(offset.x as f32, offset.y as f32)
+                            / state.layout_dom().scale_factor()
                     }
                 };
 


### PR DESCRIPTION
Winit supplies these in physical coordinates.

Please test before merging; my dev machine doesn't hit this case.