### PR TITLE
Precise Widget Recreation

### DIFF
--- a/crates/yakui-core/src/dom/mod.rs
+++ b/crates/yakui-core/src/dom/mod.rs
@@ -135,6 +135,13 @@ impl Dom {
         Ref::map(nodes, |nodes| nodes.get(index).unwrap())
     }
 
+    /// Tells whether the DOM contains a widget with the given ID.
+    pub fn contains(&self, id: WidgetId) -> bool {
+        let nodes = self.inner.nodes.borrow();
+        let index = id.index();
+        nodes.contains(index)
+    }
+
     /// Get the node with the given widget ID.
     pub fn get(&self, id: WidgetId) -> Option<Ref<'_, DomNode>> {
         let nodes = self.inner.nodes.borrow();
@@ -187,27 +194,48 @@ impl Dom {
     pub fn begin_widget<T: Widget>(&self, props: T::Props<'_>) -> Response<T::Response> {
         log::trace!("begin_widget::<{}>({props:#?}", type_name::<T>());
 
+        let parent_id = self.current();
+
         let (id, mut widget) = {
             let mut nodes = self.inner.nodes.borrow_mut();
-            let id = next_widget(&mut nodes, self.current());
-            self.inner.stack.borrow_mut().push(id);
 
-            // Component::update needs mutable access to both the widget and the
-            // DOM, so we need to rip the widget out of the tree so we can
-            // release our lock.
-            let node = nodes.get_mut(id.index()).unwrap();
-            let widget = replace(&mut node.widget, Box::new(DummyWidget));
+            if let Some(id) = next_existing_widget(&mut nodes, parent_id) {
+                // There is an existing child in this slot. It may or may not
+                // match up with the widget we're starting here.
 
-            node.next_child = 0;
-            (id, widget)
+                // Component::update needs mutable access to both the widget and the
+                // DOM, so we need to rip the widget out of the tree so we can
+                // release our lock.
+                let node = nodes.get_mut(id.index()).unwrap();
+                let widget = replace(&mut node.widget, Box::new(DummyWidget));
+
+                if widget.as_ref().type_id() == TypeId::of::<T>() {
+                    println!("happy happy happy");
+                    // happy path! we can update our widget in place.
+
+                    node.next_child = 0;
+                    (id, widget)
+                } else {
+                    // sad path! the widget changed type, so we have to burn
+                    // down the world and try again.
+
+                    let mut removed_nodes = self.inner.removed_nodes.borrow_mut();
+                    remove_recursive(&mut nodes, &mut removed_nodes, id);
+
+                    new_widget::<T>(&mut nodes, parent_id)
+                }
+            } else {
+                // we're in uncharted territory!
+
+                new_widget::<T>(&mut nodes, parent_id)
+            }
         };
 
-        // Potentially recreate the widget, then update it.
-        let response = {
-            if widget.as_ref().type_id() != TypeId::of::<T>() {
-                widget = Box::new(T::new());
-            }
+        // After this point, we've officially entered our widget.
+        self.inner.stack.borrow_mut().push(id);
 
+        // Update the widget now that we've released our locks.
+        let response = {
             let widget = widget.downcast_mut::<T>().unwrap();
             widget.update(props)
         };
@@ -262,27 +290,42 @@ impl DomInner {
     }
 }
 
-fn next_widget(nodes: &mut Arena<DomNode>, parent_id: WidgetId) -> WidgetId {
+fn next_existing_widget(nodes: &mut Arena<DomNode>, parent_id: WidgetId) -> Option<WidgetId> {
     let parent = nodes.get_mut(parent_id.index()).unwrap();
     if parent.next_child < parent.children.len() {
         let id = parent.children[parent.next_child];
-        parent.next_child += 1;
-        id
+        Some(id)
     } else {
-        let index = nodes.insert(DomNode {
-            widget: Box::new(DummyWidget),
-            parent: Some(parent_id),
-            children: Vec::new(),
-            next_child: 0,
-        });
-
-        let id = WidgetId::new(index);
-
-        let parent = nodes.get_mut(parent_id.index()).unwrap();
-        parent.children.push(id);
-        parent.next_child += 1;
-        id
+        None
     }
+}
+
+fn new_widget<T: Widget>(
+    nodes: &mut Arena<DomNode>,
+    parent_id: WidgetId,
+) -> (WidgetId, Box<dyn ErasedWidget>) {
+    let index = nodes.insert(DomNode {
+        widget: Box::new(DummyWidget),
+        parent: Some(parent_id),
+        children: Vec::new(),
+        next_child: 0,
+    });
+
+    let id = WidgetId::new(index);
+
+    let parent = nodes.get_mut(parent_id.index()).unwrap();
+
+    if parent.next_child < parent.children.len() {
+        parent.children[parent.next_child] = id;
+    } else {
+        parent.children.push(id);
+    }
+
+    parent.next_child += 1;
+
+    let widget = Box::new(T::new());
+
+    (id, widget)
 }
 
 /// Remove children from the given node that weren't present in the latest
@@ -303,5 +346,24 @@ fn trim_children(nodes: &mut Arena<DomNode>, removed_nodes: &mut Vec<WidgetId>, 
             let child = nodes.remove(child_id.index()).unwrap();
             queue.extend(child.children);
         }
+    }
+}
+
+/// Remove a widget and all of its descendants recursively.
+fn remove_recursive(nodes: &mut Arena<DomNode>, removed_nodes: &mut Vec<WidgetId>, id: WidgetId) {
+    let mut queue = VecDeque::new();
+    queue.push_back(id);
+
+    while let Some(id) = queue.pop_front() {
+        removed_nodes.push(id);
+
+        let Some(node) = nodes.get(id.index()) else {
+            continue;
+        };
+
+        let to_drop = node.children.as_slice();
+        queue.extend(to_drop);
+
+        nodes.remove(id.index());
     }
 }

--- a/crates/yakui-widgets/src/widgets/textbox.rs
+++ b/crates/yakui-widgets/src/widgets/textbox.rs
@@ -145,6 +145,9 @@ impl Widget for TextBoxWidget {
     }
 
     fn event(&mut self, ctx: EventContext<'_>, event: &WidgetEvent) -> EventResponse {
+        println!("Me: {:?}", ctx.dom.current());
+        println!("Selection: {:?}", ctx.input.selection());
+
         match event {
             WidgetEvent::FocusChanged(focused) => {
                 self.selected = *focused;


### PR DESCRIPTION
This PR currently contains work that was sitting in a Git stash on my computer for a long time. I'm opening this PR so that it doesn't grow _too_ stale, and to raise awareness that this work is happening!

## The Problem
This work spawned out of a bug report from @Ralith about textbox focus seeming to get lost between menus in a game he's working on. I pulled on the thread and found out that IDs were being reused for very different widgets. It seems like the only way that widgets ever got dropped were:

1. If a widget changed type, that widget would be updated in-place with the new widget type, keeping the same ID
2. If children were removed in an update, the list of children would get trimmed and dropped once the parent widget ended

The result of this is that IDs on the main branch of yakui are reused heavily. That... pretty much completely defeats the point of using a generational arena! The original bug occurs because the currently selected widget ID always points to a valid widget and never changes, causing it to get stuck on a widget with no focus handling code.

## The Solution
To solve this problem, this PR changes our "tree shape" reconciliation code to completely tear down subtrees whenever widget types change, and to reallocate those nodes with new IDs. That will make any widget IDs invalid instead of letting them point at now-invalid widgets.

## Current Status
I'd like to get this done this week! I'm currently blocked on other stuff our game, so it seems like a good time to clean up a bunch of yakui stuff.