### PR TITLE
RoundedRect bails out to rect if radius is zero

### DIFF
--- a/crates/yakui-widgets/src/shapes.rs
+++ b/crates/yakui-widgets/src/shapes.rs
@@ -1,7 +1,7 @@
 use std::f32::consts::TAU;
 
 use yakui_core::geometry::{Color, Rect, Vec2};
-use yakui_core::paint::{PaintDom, PaintMesh, Vertex};
+use yakui_core::paint::{PaintDom, PaintMesh, PaintRect, Vertex};
 
 pub fn cross(output: &mut PaintDom, rect: Rect, color: Color) {
     static POSITIONS: [[f32; 2]; 12] = [
@@ -179,6 +179,10 @@ impl RoundedRectangle {
     }
 
     pub fn add(&self, output: &mut PaintDom) {
+        if self.radius <= 0.0 {
+            return PaintRect::new(self.rect).add(output);
+        }
+
         let rect = self.rect;
         let color = self.color.to_linear();
 


### PR DESCRIPTION
This allows reusing the rounded rect everywhere a component can have rounded drawing needs without needed to special case the zero radius case (button region, box, ...) as well as handling pathological cases a bit nicer.

I think we could also merge `colored_box` with `round_rect` by simply having `colored_box` provide a `border_radius` parameter (we can keep the shorthand though)