### PR TITLE
yakui-wgpu: add mipmap filtering for custom textures

### DIFF
--- a/crates/bootstrap/src/lib.rs
+++ b/crates/bootstrap/src/lib.rs
@@ -119,6 +119,7 @@ async fn run(body: impl ExampleBody) {
         custom_texture::generate(&app.device, &app.queue),
         wgpu::FilterMode::Nearest,
         wgpu::FilterMode::Nearest,
+        wgpu::FilterMode::Nearest,
     );
 
     // Add a custom font for some of the examples.

--- a/crates/yakui-wgpu/src/samplers.rs
+++ b/crates/yakui-wgpu/src/samplers.rs
@@ -1,8 +1,12 @@
 pub(crate) struct Samplers {
-    nearest: wgpu::Sampler,
-    linear: wgpu::Sampler,
-    nearest_linear: wgpu::Sampler,
-    linear_nearest: wgpu::Sampler,
+    nearest_nearest_nearest: wgpu::Sampler,
+    linear_linear_nearest: wgpu::Sampler,
+    nearest_linear_nearest: wgpu::Sampler,
+    linear_nearest_nearest: wgpu::Sampler,
+    nearest_nearest_linear: wgpu::Sampler,
+    linear_linear_linear: wgpu::Sampler,
+    nearest_linear_linear: wgpu::Sampler,
+    linear_nearest_linear: wgpu::Sampler,
 }
 
 impl Samplers {
@@ -10,21 +14,34 @@ impl Samplers {
         use wgpu::FilterMode::{Linear, Nearest};
 
         Self {
-            nearest: sampler(device, Nearest, Nearest),
-            linear: sampler(device, Linear, Linear),
-            nearest_linear: sampler(device, Nearest, Linear),
-            linear_nearest: sampler(device, Linear, Nearest),
+            nearest_nearest_nearest: sampler(device, Nearest, Nearest, Nearest),
+            linear_linear_nearest: sampler(device, Linear, Linear, Nearest),
+            nearest_linear_nearest: sampler(device, Nearest, Linear, Nearest),
+            linear_nearest_nearest: sampler(device, Linear, Nearest, Nearest),
+            nearest_nearest_linear: sampler(device, Nearest, Nearest, Linear),
+            linear_linear_linear: sampler(device, Linear, Linear, Linear),
+            nearest_linear_linear: sampler(device, Nearest, Linear, Linear),
+            linear_nearest_linear: sampler(device, Linear, Nearest, Linear),
         }
     }
 
-    pub fn get(&self, min: wgpu::FilterMode, max: wgpu::FilterMode) -> &wgpu::Sampler {
+    pub fn get(
+        &self,
+        min: wgpu::FilterMode,
+        max: wgpu::FilterMode,
+        mipmap: wgpu::FilterMode,
+    ) -> &wgpu::Sampler {
         use wgpu::FilterMode::{Linear, Nearest};
 
-        match (min, max) {
-            (Nearest, Nearest) => &self.nearest,
-            (Linear, Linear) => &self.linear,
-            (Nearest, Linear) => &self.nearest_linear,
-            (Linear, Nearest) => &self.linear_nearest,
+        match (min, max, mipmap) {
+            (Nearest, Nearest, Nearest) => &self.nearest_nearest_nearest,
+            (Linear, Linear, Nearest) => &self.linear_linear_nearest,
+            (Nearest, Linear, Nearest) => &self.nearest_linear_nearest,
+            (Linear, Nearest, Nearest) => &self.linear_nearest_nearest,
+            (Nearest, Nearest, Linear) => &self.nearest_nearest_linear,
+            (Linear, Linear, Linear) => &self.linear_linear_linear,
+            (Nearest, Linear, Linear) => &self.nearest_linear_linear,
+            (Linear, Nearest, Linear) => &self.linear_nearest_linear,
         }
     }
 }
@@ -33,10 +50,12 @@ fn sampler(
     device: &wgpu::Device,
     min_filter: wgpu::FilterMode,
     mag_filter: wgpu::FilterMode,
+    mipmap_filter: wgpu::FilterMode,
 ) -> wgpu::Sampler {
     device.create_sampler(&wgpu::SamplerDescriptor {
         mag_filter,
         min_filter,
+        mipmap_filter,
         ..Default::default()
     })
 }

--- a/crates/yakui-wgpu/src/texture.rs
+++ b/crates/yakui-wgpu/src/texture.rs
@@ -16,6 +16,7 @@ pub(crate) struct GpuTexture {
     pub view: Arc<wgpu::TextureView>,
     pub min_filter: wgpu::FilterMode,
     pub mag_filter: wgpu::FilterMode,
+    pub mipmap_filter: wgpu::FilterMode,
 }
 
 impl GpuManagedTexture {


### PR DESCRIPTION
The user can provide custom textures that have been properly mipmapped.
So we allow nice trilinear filtering