### PR TITLE
Update to wgpu 0.19

### DIFF
--- a/crates/bootstrap/Cargo.toml
+++ b/crates/bootstrap/Cargo.toml
@@ -20,5 +20,5 @@ log = "0.4.17"
 pollster = "0.3.0"
 profiling = "1.0.6"
 tracy-client = { version = "0.15.1", optional = true }
-wgpu = "0.18.0"
+wgpu = "0.19.0"
 winit = "0.29.2"

--- a/crates/demo/Cargo.toml
+++ b/crates/demo/Cargo.toml
@@ -14,7 +14,7 @@ yakui-app = { path = "../yakui-app" }
 env_logger = "0.10.0"
 log = "0.4.17"
 pollster = "0.3.0"
-wgpu = { version = "0.18.0", features = ["webgl"] }
+wgpu = { version = "0.19.0", features = ["webgl"] }
 winit = "0.29.2"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/yakui-app/Cargo.toml
+++ b/crates/yakui-app/Cargo.toml
@@ -17,5 +17,5 @@ yakui-winit = { path = "../yakui-winit" }
 yakui-wgpu = { path = "../yakui-wgpu" }
 
 profiling = { version = "1.0.6", optional = true }
-wgpu = "0.18.0"
+wgpu = "0.19.0"
 winit = { version = "0.29.2", features = ["rwh_05"] }

--- a/crates/yakui-to-image/Cargo.toml
+++ b/crates/yakui-to-image/Cargo.toml
@@ -11,6 +11,6 @@ edition = "2021"
 yakui-core = { path = "../yakui-core" }
 yakui-wgpu = { path = "../yakui-wgpu" }
 
-wgpu = "0.18.0"
+wgpu = "0.19.0"
 image = { version = "0.24.4", default-features = false, features = ["png"] }
 pollster = "0.3.0"

--- a/crates/yakui-to-image/src/graphics.rs
+++ b/crates/yakui-to-image/src/graphics.rs
@@ -25,8 +25,8 @@ impl Graphics {
         let (device, queue) = adapter
             .request_device(
                 &wgpu::DeviceDescriptor {
-                    features: wgpu::Features::empty(),
-                    limits: wgpu::Limits::default(),
+                    required_features: wgpu::Features::empty(),
+                    required_limits: wgpu::Limits::default(),
                     label: None,
                 },
                 None,

--- a/crates/yakui-wgpu/Cargo.toml
+++ b/crates/yakui-wgpu/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 [dependencies]
 yakui-core = { path = "../yakui-core", version = "0.2.0" }
 
-wgpu = "0.18.0"
+wgpu = "0.19.0"
 glam = { version = "0.24.2", features = ["bytemuck"] }
 bytemuck = { version = "1.12.1", features = ["derive"] }
 thunderdome = "0.6.0"


### PR DESCRIPTION
I chose not to do anything fancy with the surface and keep the same unsafe as before. Arcanisation of the window could be done in a separate PR since this is just for the demo, so that we can use yakui with wgpu 0.19