### PR TITLE
allow cutout to be rounded

### DIFF
--- a/crates/yakui-widgets/src/widgets/cutout.rs
+++ b/crates/yakui-widgets/src/widgets/cutout.rs
@@ -1,5 +1,5 @@
+use crate::shapes::RoundedRectangle;
 use yakui_core::geometry::{Color, Constraints, Rect, Vec2};
-use yakui_core::paint::PaintRect;
 use yakui_core::widget::{LayoutContext, PaintContext, Widget};
 use yakui_core::{Response, TextureId};
 
@@ -18,6 +18,7 @@ pub struct CutOut {
     pub image_color: Color,
     pub overlay_color: Color,
     pub min_size: Vec2,
+    pub radius: f32,
 }
 
 impl CutOut {
@@ -30,6 +31,7 @@ impl CutOut {
             image_color: Color::WHITE,
             overlay_color,
             min_size: Vec2::ZERO,
+            radius: 0.0,
         }
     }
 
@@ -60,6 +62,7 @@ impl Widget for CutOutWidget {
                 image_color: Color::WHITE,
                 overlay_color: Color::CLEAR,
                 min_size: Vec2::ZERO,
+                radius: 0.0,
             },
         }
     }
@@ -91,13 +94,13 @@ impl Widget for CutOutWidget {
                 layout_node.rect.size() / ctx.layout.viewport().size(),
             );
 
-            let mut rect = PaintRect::new(layout_node.rect);
+            let mut rect = RoundedRectangle::new(layout_node.rect, self.props.radius);
             rect.color = self.props.image_color;
             rect.texture = Some((image, texture_rect));
             rect.add(ctx.paint);
         }
 
-        let mut rect = PaintRect::new(layout_node.rect);
+        let mut rect = RoundedRectangle::new(layout_node.rect, self.props.radius);
         rect.color = self.props.overlay_color;
         rect.add(ctx.paint);
 

--- a/crates/yakui/examples/blur.rs
+++ b/crates/yakui/examples/blur.rs
@@ -23,12 +23,14 @@ pub fn run(state: &mut ExampleState) {
                 let mut col = List::column();
                 col.cross_axis_alignment = CrossAxisAlignment::Stretch;
                 col.show(|| {
-                    CutOut::new(state.monkey_blurred, Color::hex(0x5cc9ff).with_alpha(0.25))
-                        .show_children(|| {
-                            Pad::all(16.0).show(|| {
-                                text(48.0, "Blur Demo");
-                            });
+                    let mut cut_out =
+                        CutOut::new(state.monkey_blurred, Color::hex(0x5cc9ff).with_alpha(0.25));
+                    cut_out.radius = 25.0;
+                    cut_out.show_children(|| {
+                        Pad::all(16.0).show(|| {
+                            text(48.0, "Blur Demo");
                         });
+                    });
 
                     CutOut::new(state.monkey_blurred, Color::hex(0x444444).with_alpha(0.1))
                         .show_children(|| {


### PR DESCRIPTION
![image](https://github.com/SecondHalfGames/yakui/assets/5420739/0857fd94-e734-4d28-ac15-db348a9b85f2)

Also fixes "color" not being passed to `PaintRect` when using fallback and optimize allocations a bit

Also means RoundedRectangle now supports images so that can be used elsewhere