### PR TITLE
add more main axis alignments

### DIFF
--- a/crates/yakui-core/src/types.rs
+++ b/crates/yakui-core/src/types.rs
@@ -59,9 +59,18 @@ pub enum MainAxisAlignment {
     ///
     /// For a top-down list, this is the bottom of the container.
     End,
-    // SpaceAround,
-    // SpaceBetween,
-    // SpaceEvenly,
+
+    /// Spread the items evenly where the gap at the start and end of the container
+    /// is half the size of the gap between each adjacent item.
+    SpaceAround,
+
+    /// Spread the items evenly with no gap at the start and the end of the container.
+    /// If there is only one item, it will be at the start.
+    SpaceBetween,
+
+    /// Spread the items evenly where the gap at the start and end of the container
+    /// is the same size as the gap between each adjacent item.
+    SpaceEvenly,
 }
 
 /// Defines alignment for items within a container's main axis when there is space left.

--- a/crates/yakui/examples/main_alignment.rs
+++ b/crates/yakui/examples/main_alignment.rs
@@ -8,6 +8,9 @@ pub fn run(state: &mut ExampleState) {
         MainAxisAlignment::Start,
         MainAxisAlignment::Center,
         MainAxisAlignment::End,
+        MainAxisAlignment::SpaceBetween,
+        MainAxisAlignment::SpaceAround,
+        MainAxisAlignment::SpaceEvenly,
     ];
 
     let index = (state.time.floor() as usize) % alignments.len();


### PR DESCRIPTION
Add the Space* alignments using the same algorithm as Flutter:

https://github.com/flutter/flutter/blob/67457e669f/packages/flutter/lib/src/rendering/flex.dart#L963

(which is also the CSS spec, the Flutter doc is really vague about the details).

![Screenshot from 2024-01-24 13-39-27](https://github.com/SecondHalfGames/yakui/assets/5420739/c507087c-e5fe-4137-9adb-aa9efc36fa25)
