### PR TITLE
Update dependencies and remove palette (2x improvement in compile time)

### DIFF
--- a/crates/yakui-core/Cargo.toml
+++ b/crates/yakui-core/Cargo.toml
@@ -10,11 +10,11 @@ edition = "2021"
 
 [dependencies]
 anymap = "0.12.1"
-bitflags = "1.3.2"
-glam = "0.24.2"
-keyboard-types = { version = "0.6.2", default-features = false }
+bitflags = "2.4.2"
+glam = "0.25.0"
+keyboard-types = { version = "0.7.0", default-features = false }
 log = "0.4.17"
-palette = "0.7.4"
+fast-srgb8 = "1.0.0"
 profiling = "1.0.6"
 smallvec = "1.9.0"
 thunderdome = "0.6.0"

--- a/crates/yakui-core/src/event.rs
+++ b/crates/yakui-core/src/event.rs
@@ -120,7 +120,7 @@ pub enum EventResponse {
 
 bitflags::bitflags! {
     /// A bitfield of events that a widget can register to be notified about.
-    #[derive(Default)]
+    #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy, Default)]
     pub struct EventInterest: u8 {
         /// Notify this widget of mouse events occuring within its layout
         /// rectangle.
@@ -140,6 +140,6 @@ bitflags::bitflags! {
         const FOCUSED_KEYBOARD = 16;
 
         /// Notify this widget of all mouse events.
-        const MOUSE_ALL = Self::MOUSE_INSIDE.bits | Self::MOUSE_OUTSIDE.bits | Self::MOUSE_MOVE.bits;
+        const MOUSE_ALL = Self::MOUSE_INSIDE.bits() | Self::MOUSE_OUTSIDE.bits() | Self::MOUSE_MOVE.bits();
     }
 }

--- a/crates/yakui-core/src/geometry/color.rs
+++ b/crates/yakui-core/src/geometry/color.rs
@@ -48,9 +48,10 @@ impl Color {
 
     /// Create a new `Color` from a linear RGB color.
     pub fn from_linear(value: Vec4) -> Self {
-        let linear = palette::LinSrgba::new(value.x, value.y, value.z, value.w);
-        let (r, g, b, a) = palette::Srgba::<u8>::from_linear(linear).into_components();
-
+        let r = fast_srgb8::f32_to_srgb8(value.x);
+        let g = fast_srgb8::f32_to_srgb8(value.y);
+        let b = fast_srgb8::f32_to_srgb8(value.z);
+        let a = (value.w * 255.0).round() as u8;
         Self::rgba(r, g, b, a)
     }
 
@@ -70,11 +71,11 @@ impl Color {
 
     /// Convert this color to a linear RGB color.
     pub fn to_linear(&self) -> Vec4 {
-        palette::Srgba::new(self.r, self.g, self.b, self.a)
-            .into_format::<f32, f32>()
-            .into_linear()
-            .into_components()
-            .into()
+        let r = fast_srgb8::srgb8_to_f32(self.r);
+        let g = fast_srgb8::srgb8_to_f32(self.g);
+        let b = fast_srgb8::srgb8_to_f32(self.b);
+        let a = self.a as f32 / 255.0;
+        Vec4::new(r, g, b, a)
     }
 
     /// Blend with `other` in linear space

--- a/crates/yakui-wgpu/Cargo.toml
+++ b/crates/yakui-wgpu/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 yakui-core = { path = "../yakui-core", version = "0.2.0" }
 
 wgpu = "0.19.0"
-glam = { version = "0.24.2", features = ["bytemuck"] }
+glam = { version = "0.25.0", features = ["bytemuck"] }
 bytemuck = { version = "1.12.1", features = ["derive"] }
 thunderdome = "0.6.0"
 profiling = "1.0.6"


### PR DESCRIPTION
- Update to bitflags 2 (need to derive by hand, bits -> bits())
- keyboards-types also updates bitflags to v2
- Remove palette in favor of `fast-srgb` (which palette used under the hood)

Compile time improvements from quick testing:
```bash
cargo clean && cargo build -p yakui

Before: ~6.2s
After:  ~3.4s
```

<details>
<summary> old tree </summary>

```
> cargo tree -p yakui -e normal
yakui v0.2.0 (/home/pdouady/repos/yakui/crates/yakui)
├── yakui-core v0.2.0 (/home/pdouady/repos/yakui/crates/yakui-core)
│   ├── anymap v0.12.1
│   ├── bitflags v1.3.2
│   ├── glam v0.24.2
│   ├── keyboard-types v0.6.2
│   │   └── bitflags v1.3.2
│   ├── log v0.4.20
│   ├── palette v0.7.4
│   │   ├── approx v0.5.1
│   │   │   └── num-traits v0.2.17
│   │   ├── fast-srgb8 v1.0.0
│   │   ├── palette_derive v0.7.4 (proc-macro)
│   │   │   ├── proc-macro2 v1.0.76
│   │   │   │   └── unicode-ident v1.0.12
│   │   │   ├── quote v1.0.35
│   │   │   │   └── proc-macro2 v1.0.76 (*)
│   │   │   └── syn v2.0.48
│   │   │       ├── proc-macro2 v1.0.76 (*)
│   │   │       ├── quote v1.0.35 (*)
│   │   │       └── unicode-ident v1.0.12
│   │   └── phf v0.11.2
│   │       ├── phf_macros v0.11.2 (proc-macro)
│   │       │   ├── phf_generator v0.11.2
│   │       │   │   ├── phf_shared v0.11.2
│   │       │   │   │   └── siphasher v0.3.11
│   │       │   │   └── rand v0.8.5
│   │       │   │       └── rand_core v0.6.4
│   │       │   ├── phf_shared v0.11.2 (*)
│   │       │   ├── proc-macro2 v1.0.76 (*)
│   │       │   ├── quote v1.0.35 (*)
│   │       │   └── syn v2.0.48 (*)
│   │       └── phf_shared v0.11.2 (*)
│   ├── profiling v1.0.13
│   │   └── profiling-procmacros v1.0.13 (proc-macro)
│   │       ├── quote v1.0.35 (*)
│   │       └── syn v2.0.48 (*)
│   ├── smallvec v1.12.0
│   └── thunderdome v0.6.1
└── yakui-widgets v0.2.0 (/home/pdouady/repos/yakui/crates/yakui-widgets)
    ├── fontdue v0.7.3
    │   ├── hashbrown v0.13.2
    │   │   └── ahash v0.8.7
    │   │       ├── cfg-if v1.0.0
    │   │       ├── once_cell v1.19.0
    │   │       └── zerocopy v0.7.32
    │   └── ttf-parser v0.15.2
    ├── smol_str v0.1.24
    │   └── serde v1.0.195
    ├── thunderdome v0.6.1
    └── yakui-core v0.2.0 (/home/pdouady/repos/yakui/crates/yakui-core) (*)
```
</details>

<details>
<summary>new tree</summary>

```
> cargo tree -p yakui -e normal
yakui v0.2.0 (/home/pdouady/repos/yakui/crates/yakui)
├── yakui-core v0.2.0 (/home/pdouady/repos/yakui/crates/yakui-core)
│   ├── anymap v0.12.1
│   ├── bitflags v2.4.2
│   ├── fast-srgb8 v1.0.0
│   ├── glam v0.25.0
│   ├── keyboard-types v0.7.0
│   │   └── bitflags v2.4.2
│   ├── log v0.4.20
│   ├── profiling v1.0.13
│   │   └── profiling-procmacros v1.0.13 (proc-macro)
│   │       ├── quote v1.0.35
│   │       │   └── proc-macro2 v1.0.76
│   │       │       └── unicode-ident v1.0.12
│   │       └── syn v2.0.48
│   │           ├── proc-macro2 v1.0.76 (*)
│   │           ├── quote v1.0.35 (*)
│   │           └── unicode-ident v1.0.12
│   ├── smallvec v1.12.0
│   └── thunderdome v0.6.1
└── yakui-widgets v0.2.0 (/home/pdouady/repos/yakui/crates/yakui-widgets)
    ├── fontdue v0.7.3
    │   ├── hashbrown v0.13.2
    │   │   └── ahash v0.8.7
    │   │       ├── cfg-if v1.0.0
    │   │       ├── once_cell v1.19.0
    │   │       └── zerocopy v0.7.32
    │   └── ttf-parser v0.15.2
    ├── smol_str v0.1.24
    │   └── serde v1.0.195
    ├── thunderdome v0.6.1
    └── yakui-core v0.2.0 (/home/pdouady/repos/yakui/crates/yakui-core) (*)
```
</details>