### PR TITLE
Add pivot to reflow

### DIFF
--- a/crates/yakui-core/src/types.rs
+++ b/crates/yakui-core/src/types.rs
@@ -219,3 +219,40 @@ impl Alignment {
     pub const BOTTOM_CENTER: Self = Self::new(0.5, 1.0);
     pub const BOTTOM_RIGHT: Self = Self::new(1.0, 1.0);
 }
+
+/// Defines a reference point for a widget.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Pivot {
+    x: f32,
+    y: f32,
+}
+
+impl Pivot {
+    /// Create a new `Pivot` given an anchor point.
+    ///
+    /// `0.0, 0.0` is the top left corner of the widget, while `1.0, 1.0` is
+    /// the bottom right corner.
+    pub const fn new(x: f32, y: f32) -> Self {
+        Self { x, y }
+    }
+
+    /// Returns the point for a pivot value.
+    pub const fn as_vec2(&self) -> Vec2 {
+        Vec2::new(self.x, self.y)
+    }
+}
+
+#[allow(missing_docs)]
+impl Pivot {
+    pub const TOP_LEFT: Self = Self::new(0.0, 0.0);
+    pub const TOP_CENTER: Self = Self::new(0.5, 0.0);
+    pub const TOP_RIGHT: Self = Self::new(1.0, 0.0);
+
+    pub const CENTER_LEFT: Self = Self::new(0.0, 0.5);
+    pub const CENTER: Self = Self::new(0.5, 0.5);
+    pub const CENTER_RIGHT: Self = Self::new(1.0, 0.5);
+
+    pub const BOTTOM_LEFT: Self = Self::new(0.0, 1.0);
+    pub const BOTTOM_CENTER: Self = Self::new(0.5, 1.0);
+    pub const BOTTOM_RIGHT: Self = Self::new(1.0, 1.0);
+}

--- a/crates/yakui-widgets/src/shorthand.rs
+++ b/crates/yakui-widgets/src/shorthand.rs
@@ -7,7 +7,7 @@ use std::borrow::Cow;
 
 use yakui_core::geometry::{Color, Constraints, Dim2, Vec2};
 use yakui_core::widget::PaintContext;
-use yakui_core::{Alignment, ManagedTextureId, Response, TextureId};
+use yakui_core::{Alignment, ManagedTextureId, Pivot, Response, TextureId};
 
 use crate::widgets::{
     Align, AlignResponse, Button, ButtonResponse, Canvas, CanvasResponse, Checkbox,
@@ -170,10 +170,11 @@ pub fn slider(value: f64, min: f64, max: f64) -> Response<SliderResponse> {
 /// See [Reflow].
 pub fn reflow(
     anchor: Alignment,
+    pivot: Pivot,
     offset: Dim2,
     children: impl FnOnce(),
 ) -> Response<ReflowResponse> {
-    Reflow::new(anchor, offset).show(children)
+    Reflow::new(anchor, pivot, offset).show(children)
 }
 
 /// See [Opaque].

--- a/crates/yakui-widgets/tests/snapshot.rs
+++ b/crates/yakui-widgets/tests/snapshot.rs
@@ -1,6 +1,6 @@
 use yakui::{Constraints, CrossAxisAlignment, Dim2, MainAxisAlignment, MainAxisSize, Vec2};
 use yakui_core::geometry::Color;
-use yakui_core::Alignment;
+use yakui_core::{Alignment, Pivot};
 use yakui_test::{run, Test};
 use yakui_widgets::widgets::{Button, List, Pad, UnconstrainedBox};
 use yakui_widgets::{
@@ -351,13 +351,18 @@ fn row_reflow() {
                 colored_box(Color::RED, [50.0, 50.0]);
                 colored_box(Color::GREEN, [50.0, 50.0]);
 
-                reflow(Alignment::BOTTOM_RIGHT, Dim2::ZERO, || {
+                reflow(Alignment::BOTTOM_RIGHT, Pivot::TOP_LEFT, Dim2::ZERO, || {
                     colored_box(Color::BLUE, [100.0, 50.0]);
                 });
 
-                reflow(Alignment::BOTTOM_RIGHT, Dim2::pixels(0.0, 50.0), || {
-                    colored_box(Color::WHITE, [100.0, 100.0]);
-                });
+                reflow(
+                    Alignment::BOTTOM_RIGHT,
+                    Pivot::TOP_LEFT,
+                    Dim2::pixels(0.0, 50.0),
+                    || {
+                        colored_box(Color::WHITE, [100.0, 100.0]);
+                    },
+                );
             });
         });
     });

--- a/crates/yakui/examples/dropdown.rs
+++ b/crates/yakui/examples/dropdown.rs
@@ -5,6 +5,7 @@
 
 use yakui::widgets::Layer;
 use yakui::{align, button, column, reflow, use_state, widgets::Pad, Alignment, Dim2};
+use yakui_core::Pivot;
 
 pub fn run() {
     let open = use_state(|| false);
@@ -25,7 +26,7 @@ pub fn run() {
                 if open.get() {
                     Pad::ZERO.show(|| {
                         Layer::new().show(|| {
-                            reflow(Alignment::BOTTOM_LEFT, Dim2::ZERO, || {
+                            reflow(Alignment::BOTTOM_LEFT, Pivot::TOP_LEFT, Dim2::ZERO, || {
                                 column(|| {
                                     let current = selected.get();
                                     for (i, option) in options.iter().enumerate() {


### PR DESCRIPTION
This allows reflowing while taking into account the child size. I personally need this to be able to show a tooltip over a button (when hovered for a bit) that is nicely centered.

I introduced a new "Pivot" type to avoid accidentally swapping the anchor and the pivot arguments in the `reflow` shorthand.

Another idea: This could be implemented as a separate `Pivot` widget with the same offset logic.
Could also be added to the `Offset` widget which would now also take relative (pivot) coordinates.
(Could be worth simplifying `Flow::Relative` removing offset since the Offset widget can already do this?)

Some screenshots:

Backward compat: Pivot is `TOP_LEFT`.
![Screenshot from 2024-02-07 16-34-21](https://github.com/SecondHalfGames/yakui/assets/5420739/4b1173d5-dceb-461a-918e-c4906d1b0dd4)

Pivot is 'CENTER':
![Screenshot from 2024-02-07 16-51-56](https://github.com/SecondHalfGames/yakui/assets/5420739/fd64931f-47bb-4465-b17f-c47dcc15b4a5)


Pivot is equal to anchor:
![Screenshot from 2024-02-07 16-51-11](https://github.com/SecondHalfGames/yakui/assets/5420739/a7371aee-c6ce-4eb9-91fc-b2ce32bcbabc)


