### PR TITLE
Fix broken doc references

### DIFF
--- a/crates/yakui-vulkan/src/lib.rs
+++ b/crates/yakui-vulkan/src/lib.rs
@@ -378,12 +378,12 @@ impl YakuiVulkan {
         self.uploads.phase_submitted();
     }
 
-    /// Call when the commands associated with the oldest call to `commands_submitted` have finished.
+    /// Call when the commands associated with the oldest call to `transfers_submitted` have finished.
     ///
     /// ## Safety
     ///
-    /// Those commands recorded prior to the oldest call to `commands_submitted` not yet associated
-    /// with a call to `commands_finished` must not be executing.
+    /// Those commands recorded prior to the oldest call to `transfers_submitted` not yet associated
+    /// with a call to `transfers_finished` must not be executing.
     pub unsafe fn transfers_finished(&mut self, vulkan_context: &VulkanContext) {
         self.uploads.phase_executed(vulkan_context);
     }

--- a/crates/yakui-widgets/src/shorthand.rs
+++ b/crates/yakui-widgets/src/shorthand.rs
@@ -54,7 +54,7 @@ pub fn button<S: Into<Cow<'static, str>>>(text: S) -> Response<ButtonResponse> {
     Button::styled(text.into()).show()
 }
 
-/// See [ColoredCircle].
+/// See [Circle].
 pub fn colored_circle<S: Into<f32>>(color: Color, size: S) -> Response<CircleResponse> {
     let mut circle = Circle::new();
     circle.min_radius = size.into();


### PR DESCRIPTION
I believe most of these changes are non-controversial, although someone other than me may want to double-check that `transfers_submitted` and `transfers_finished` are the right function names to reference, although I don't see what else they could be.

One change I considered making as well was the `size` parameter in `colored_circle` to `min_radius` to match the name of the `Circle` struct field. When I first used that function, I was a surprised that the `size` parameter was being ignored, even though it made sense in retrospect. However, I also noticed that many other functions would also need their parameters renamed if I went this route, so this PR only fixes broken references.