### PR TITLE
Fix validation warnings on macOS

### DIFF
--- a/crates/yakui-vulkan/examples/demo.rs
+++ b/crates/yakui-vulkan/examples/demo.rs
@@ -363,7 +363,8 @@ impl VulkanTest {
 
         let mut descriptor_indexing_features =
             vk::PhysicalDeviceDescriptorIndexingFeatures::default()
-                .descriptor_binding_partially_bound(true);
+                .descriptor_binding_partially_bound(true)
+                .descriptor_binding_sampled_image_update_after_bind(true);
 
         let device_create_info = vk::DeviceCreateInfo::default()
             .queue_create_infos(std::slice::from_ref(&queue_info))

--- a/crates/yakui-vulkan/src/descriptors.rs
+++ b/crates/yakui-vulkan/src/descriptors.rs
@@ -18,6 +18,7 @@ impl Descriptors {
             device.create_descriptor_pool(
                 &vk::DescriptorPoolCreateInfo::default()
                     .max_sets(1)
+                    .flags(vk::DescriptorPoolCreateFlags::UPDATE_AFTER_BIND)
                     .pool_sizes(&[vk::DescriptorPoolSize {
                         ty: vk::DescriptorType::COMBINED_IMAGE_SAMPLER,
                         descriptor_count: 1000,
@@ -27,7 +28,8 @@ impl Descriptors {
         }
         .unwrap();
 
-        let flags = [vk::DescriptorBindingFlags::PARTIALLY_BOUND];
+        let flags = [vk::DescriptorBindingFlags::PARTIALLY_BOUND
+            | vk::DescriptorBindingFlags::UPDATE_AFTER_BIND];
         let mut binding_flags =
             vk::DescriptorSetLayoutBindingFlagsCreateInfo::default().binding_flags(&flags);
 
@@ -41,6 +43,7 @@ impl Descriptors {
                         descriptor_count: 1000,
                         ..Default::default()
                     }])
+                    .flags(vk::DescriptorSetLayoutCreateFlags::UPDATE_AFTER_BIND_POOL)
                     .push_next(&mut binding_flags),
                 None,
             )


### PR DESCRIPTION
Sets various `UPDATE_AFTER_BIND_POOL_BIT` flags on descriptors to allow reasonable amounts of image samplers in our descriptor sets on platforms like macOS.

Closes #160