### PR TITLE
fix clippy lints

### DIFF
--- a/crates/yakui-app/src/lib.rs
+++ b/crates/yakui-app/src/lib.rs
@@ -206,11 +206,7 @@ impl Graphics {
             }
 
             Event::NewEvents(cause) => {
-                if *cause == StartCause::Init {
-                    self.is_init = true;
-                } else {
-                    self.is_init = false;
-                }
+                self.is_init = *cause == StartCause::Init;
             }
 
             Event::WindowEvent {

--- a/crates/yakui-core/src/context.rs
+++ b/crates/yakui-core/src/context.rs
@@ -8,7 +8,7 @@ use crate::dom::Dom;
 type Storage<T> = RefCell<Option<T>>;
 
 thread_local! {
-    static CURRENT_DOM: Storage<Dom> = RefCell::new(None);
+    static CURRENT_DOM: Storage<Dom> = const { RefCell::new(None) };
 }
 
 /// If there is a DOM currently being updated on this thread, returns a

--- a/crates/yakui-core/src/geometry/constraints.rs
+++ b/crates/yakui-core/src/geometry/constraints.rs
@@ -1,5 +1,3 @@
-use std::f32::INFINITY;
-
 use glam::Vec2;
 
 /// Defines box constraints used for layout.
@@ -36,7 +34,7 @@ impl Constraints {
     pub fn none() -> Self {
         Self {
             min: Vec2::ZERO,
-            max: Vec2::new(INFINITY, INFINITY),
+            max: Vec2::new(f32::INFINITY, f32::INFINITY),
         }
     }
 

--- a/crates/yakui-vulkan/examples/demo.rs
+++ b/crates/yakui-vulkan/examples/demo.rs
@@ -85,11 +85,7 @@ fn main() {
         } => elwt.exit(),
 
         Event::NewEvents(cause) => {
-            if cause == winit::event::StartCause::Init {
-                winit_initializing = true;
-            } else {
-                winit_initializing = false;
-            }
+            winit_initializing = cause == winit::event::StartCause::Init;
         }
 
         Event::AboutToWait => {
@@ -148,21 +144,18 @@ fn main() {
                     event:
                         KeyEvent {
                             state: ElementState::Released,
-                            physical_key,
+                            physical_key: PhysicalKey::Code(KeyCode::KeyA),
                             ..
                         },
                     ..
                 },
             ..
-        } => match physical_key {
-            PhysicalKey::Code(KeyCode::KeyA) => {
-                gui_state.which_image = match &gui_state.which_image {
-                    WhichImage::Monkey => WhichImage::Dog,
-                    WhichImage::Dog => WhichImage::Monkey,
-                }
+        } => {
+            gui_state.which_image = match &gui_state.which_image {
+                WhichImage::Monkey => WhichImage::Dog,
+                WhichImage::Dog => WhichImage::Monkey,
             }
-            _ => {}
-        },
+        }
         _ => (),
     });
 
@@ -214,7 +207,7 @@ fn gui(gui_state: &GuiState) {
     use yakui::{column, label, row, text, widgets::Text, Color};
     let (animal, texture): (&'static str, yakui::TextureId) = match gui_state.which_image {
         WhichImage::Monkey => ("monkye", gui_state.monkey.into()),
-        WhichImage::Dog => ("dog haha good boy", gui_state.dog.into()),
+        WhichImage::Dog => ("dog haha good boy", gui_state.dog),
     };
     column(|| {
         row(|| {
@@ -590,7 +583,7 @@ impl VulkanTest {
                 .swapchain_loader
                 .acquire_next_image(
                     self.swapchain,
-                    std::u64::MAX,
+                    u64::MAX,
                     self.present_complete_semaphore,
                     vk::Fence::null(),
                 )
@@ -603,7 +596,7 @@ impl VulkanTest {
                 .wait_for_fences(
                     std::slice::from_ref(&self.draw_commands_reuse_fence),
                     true,
-                    std::u64::MAX,
+                    u64::MAX,
                 )
                 .unwrap();
             device

--- a/crates/yakui-wgpu/src/lib.rs
+++ b/crates/yakui-wgpu/src/lib.rs
@@ -374,10 +374,9 @@ impl YakuiWgpu {
         profiling::scope!("update_textures");
 
         for (id, texture) in paint.textures() {
-            if !self.managed_textures.contains_key(&id) {
-                self.managed_textures
-                    .insert(id, GpuManagedTexture::new(device, queue, texture));
-            }
+            self.managed_textures
+                .entry(id)
+                .or_insert_with(|| GpuManagedTexture::new(device, queue, texture));
         }
 
         for (id, change) in paint.texture_edits() {

--- a/crates/yakui-widgets/src/widgets/list.rs
+++ b/crates/yakui-widgets/src/widgets/list.rs
@@ -1,5 +1,3 @@
-use std::f32::INFINITY;
-
 use yakui_core::geometry::{Constraints, FlexFit, Vec2};
 use yakui_core::widget::{LayoutContext, Widget};
 use yakui_core::{CrossAxisAlignment, Direction, Flow, MainAxisAlignment, MainAxisSize, Response};
@@ -137,7 +135,7 @@ impl Widget for ListWidget {
 
             let constraints = Constraints {
                 min: direction.vec2(0.0, cross_axis_min),
-                max: direction.vec2(INFINITY, cross_axis_max),
+                max: direction.vec2(f32::INFINITY, cross_axis_max),
             };
 
             let size = ctx.calculate_layout(child_index, constraints);

--- a/crates/yakui-widgets/src/widgets/max_width.rs
+++ b/crates/yakui-widgets/src/widgets/max_width.rs
@@ -1,5 +1,3 @@
-use std::f32::INFINITY;
-
 use yakui_core::geometry::{Constraints, Vec2};
 use yakui_core::widget::{LayoutContext, Widget};
 use yakui_core::Response;
@@ -41,7 +39,7 @@ impl Widget for MaxWidthWidget {
     fn new() -> Self {
         Self {
             props: MaxWidth {
-                max_width: INFINITY,
+                max_width: f32::INFINITY,
             },
         }
     }

--- a/crates/yakui-widgets/src/widgets/textbox.rs
+++ b/crates/yakui-widgets/src/widgets/textbox.rs
@@ -1,5 +1,4 @@
 use std::cell::RefCell;
-use std::f32::INFINITY;
 use std::mem;
 use std::rc::Rc;
 
@@ -349,7 +348,7 @@ fn pick_text_line(layout: &Layout, pos_y: f32) -> Option<&LinePosition> {
     let lines = layout.lines()?;
 
     let mut closest_line = 0;
-    let mut closest_line_dist = INFINITY;
+    let mut closest_line_dist = f32::INFINITY;
     for (index, line) in lines.iter().enumerate() {
         let dist = (pos_y - line.baseline_y).abs();
         if dist < closest_line_dist {
@@ -368,7 +367,7 @@ fn pick_character_on_line(
     pos_x: f32,
 ) -> usize {
     let mut closest_byte_offset = 0;
-    let mut closest_dist = INFINITY;
+    let mut closest_dist = f32::INFINITY;
 
     let possible_positions = layout
         .glyphs()

--- a/crates/yakui-widgets/src/widgets/unconstrained_box.rs
+++ b/crates/yakui-widgets/src/widgets/unconstrained_box.rs
@@ -1,5 +1,3 @@
-use std::f32::INFINITY;
-
 use yakui_core::geometry::{Constraints, Vec2};
 use yakui_core::widget::{LayoutContext, Widget};
 use yakui_core::Response;
@@ -58,13 +56,13 @@ impl Widget for UnconstrainedBoxWidget {
         let (min_x, max_x) = if self.props.constrain_x {
             (0.0, input.max.x)
         } else {
-            (0.0, INFINITY)
+            (0.0, f32::INFINITY)
         };
 
         let (min_y, max_y) = if self.props.constrain_y {
             (0.0, input.max.y)
         } else {
-            (0.0, INFINITY)
+            (0.0, f32::INFINITY)
         };
 
         let constraints = Constraints {

--- a/crates/yakui/examples/blur.rs
+++ b/crates/yakui/examples/blur.rs
@@ -1,5 +1,3 @@
-use std::f32::INFINITY;
-
 use bootstrap::ExampleState;
 use yakui::widgets::CutOut;
 use yakui::{draggable, image, offset, text, use_state, Color, Constraints, Vec2};
@@ -16,7 +14,7 @@ pub fn run(state: &mut ExampleState) {
         let res = draggable(|| {
             let constraints = Constraints {
                 min: Vec2::new(400.0, 0.0),
-                max: Vec2::new(400.0, INFINITY),
+                max: Vec2::new(400.0, f32::INFINITY),
             };
 
             constrained(constraints, || {


### PR DESCRIPTION
This PR fixes various nits and whatnots that clippy yells at me about (as of MSRV).

The majority of these were replacing `use std::f32::INFINITY` with a simpler `f32::INFINITY`, apparently because `std::f32::INFINITY` will be deprecated at some point? It seems all a bit vague.

I don't feel strongly about any of these changes in particular, but I do like a project to have no clippy warnings, so if there's anything you'd like to revert here, just lmk and I'll swap to making clippy::allows instead