### PR TITLE
Put TextBox cursor back in bounds if the text changes (#168)

### DIFF
--- a/crates/yakui-widgets/src/widgets/textbox.rs
+++ b/crates/yakui-widgets/src/widgets/textbox.rs
@@ -93,6 +93,9 @@ impl Widget for TextBoxWidget {
             text = &self.props.placeholder;
         }
 
+        // Make sure the cursor is within bounds if the text has changed
+        self.cursor = self.cursor.min(text.len());
+
         let mut render = RenderTextBox::new(text.clone());
         render.style = self.props.style.clone();
         render.selected = self.selected;


### PR DESCRIPTION
Set the textbox cursor to be within the range of the text in `TextBoxWidget::update`.

Should fix #168