### PR TITLE
panic when missing font

### DIFF
--- a/crates/yakui-widgets/src/widgets/render_text.rs
+++ b/crates/yakui-widgets/src/widgets/render_text.rs
@@ -78,7 +78,10 @@ impl Widget for RenderTextWidget {
             Some(font) => font,
             None => {
                 // TODO: Log once that we were unable to find this font.
-                return input.min;
+                panic!(
+                    "font `{}` was set, but was not registered",
+                    self.props.style.font
+                );
             }
         };
 


### PR DESCRIPTION
This PR simply adds a panic when a font is missing. This obviously would be a breaking change for some users who might rely on the current behavior.

I'm not sure that `panic` is the correct decision here, but the API really doesn't allow for anything besides that, or the current behavior here. I am making this PR because I believe that panicking is superior given only those two options.

I am open to this PR being rejected without too much complaining -- I understand there might be a difference in direction here