### PR TITLE
Use `vk::Format::R8G8B8A8_SRGB` for srgb textures in vulkan

### DIFF
--- a/crates/yakui-vulkan/src/vulkan_texture.rs
+++ b/crates/yakui-vulkan/src/vulkan_texture.rs
@@ -168,7 +168,7 @@ impl VulkanTexture {
 
 fn get_format(yakui_format: yakui::paint::TextureFormat) -> vk::Format {
     match yakui_format {
-        yakui::paint::TextureFormat::Rgba8Srgb => vk::Format::R8G8B8A8_UNORM,
+        yakui::paint::TextureFormat::Rgba8Srgb => vk::Format::R8G8B8A8_SRGB,
         yakui::paint::TextureFormat::R8 => vk::Format::R8_UNORM,
         _ => panic!("Unsupported texture format: {yakui_format:?}"),
     }


### PR DESCRIPTION
Fixes #174 