### PR TITLE
Support setting address modes for yakui textures

### DIFF
--- a/crates/bootstrap/src/lib.rs
+++ b/crates/bootstrap/src/lib.rs
@@ -120,6 +120,7 @@ async fn run(body: impl ExampleBody) {
         wgpu::FilterMode::Nearest,
         wgpu::FilterMode::Nearest,
         wgpu::FilterMode::Nearest,
+        wgpu::AddressMode::ClampToEdge,
     );
 
     // Add a custom font for some of the examples.

--- a/crates/yakui-core/src/paint/texture.rs
+++ b/crates/yakui-core/src/paint/texture.rs
@@ -11,6 +11,9 @@ pub struct Texture {
 
     /// How to filter the texture when it needs to be magnified (made larger)
     pub mag_filter: TextureFilter,
+
+    /// How to handle texture addressing
+    pub address_mode: AddressMode,
 }
 
 impl std::fmt::Debug for Texture {
@@ -20,6 +23,7 @@ impl std::fmt::Debug for Texture {
             .field("size", &self.size)
             .field("min_filter", &self.min_filter)
             .field("mag_filter", &self.mag_filter)
+            .field("address_mode", &self.address_mode)
             .finish_non_exhaustive()
     }
 }
@@ -46,6 +50,16 @@ pub enum TextureFilter {
     Nearest,
 }
 
+/// Which kind of address mode to use when UVs go outside the range `[0, 1]`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum AddressMode {
+    /// Clamp to the edge of the texture
+    ClampToEdge,
+
+    /// Repeat the texture
+    Repeat,
+}
+
 impl Texture {
     /// Create a new texture from its format, size, and data.
     pub fn new(format: TextureFormat, size: UVec2, data: Vec<u8>) -> Self {
@@ -55,6 +69,7 @@ impl Texture {
             data,
             min_filter: TextureFilter::Nearest,
             mag_filter: TextureFilter::Linear,
+            address_mode: AddressMode::ClampToEdge,
         }
     }
 

--- a/crates/yakui-vulkan/examples/demo.rs
+++ b/crates/yakui-vulkan/examples/demo.rs
@@ -182,6 +182,7 @@ fn create_vulkan_texture_info(
         resolution,
         filter,
         filter,
+        vk::SamplerAddressMode::CLAMP_TO_EDGE,
     )
 }
 

--- a/crates/yakui-vulkan/src/vulkan_texture.rs
+++ b/crates/yakui-vulkan/src/vulkan_texture.rs
@@ -24,6 +24,7 @@ pub struct VulkanTextureCreateInfo<T> {
     resolution: vk::Extent2D,
     min_filter: vk::Filter,
     mag_filter: vk::Filter,
+    address_mode: vk::SamplerAddressMode,
 }
 
 impl<T: AsRef<[u8]>> VulkanTextureCreateInfo<T> {
@@ -35,6 +36,7 @@ impl<T: AsRef<[u8]>> VulkanTextureCreateInfo<T> {
         resolution: vk::Extent2D,
         min_filter: vk::Filter,
         mag_filter: vk::Filter,
+        address_mode: vk::SamplerAddressMode,
     ) -> Self {
         Self {
             image_data,
@@ -42,6 +44,7 @@ impl<T: AsRef<[u8]>> VulkanTextureCreateInfo<T> {
             resolution,
             min_filter,
             mag_filter,
+            address_mode,
         }
     }
 }
@@ -98,9 +101,9 @@ impl VulkanTexture {
             resolution,
             min_filter,
             mag_filter,
+            address_mode,
         } = create_info;
 
-        let address_mode = vk::SamplerAddressMode::CLAMP_TO_EDGE;
         let (image, memory) = unsafe { vulkan_context.create_image(resolution, format) };
         unsafe {
             queue.push(vulkan_context, image, resolution, image_data.as_ref());
@@ -150,10 +153,18 @@ impl VulkanTexture {
 
         let mag_filter = get_filter(texture.mag_filter);
         let min_filter = get_filter(texture.min_filter);
+        let address_mode = get_address_mode(texture.address_mode);
         VulkanTexture::new(
             vulkan_context,
             descriptors,
-            VulkanTextureCreateInfo::new(image_data, format, resolution, min_filter, mag_filter),
+            VulkanTextureCreateInfo::new(
+                image_data,
+                format,
+                resolution,
+                min_filter,
+                mag_filter,
+                address_mode,
+            ),
             queue,
         )
     }
@@ -178,6 +189,13 @@ fn get_filter(yakui_filter: yakui::paint::TextureFilter) -> vk::Filter {
     match yakui_filter {
         yakui::paint::TextureFilter::Linear => vk::Filter::LINEAR,
         yakui::paint::TextureFilter::Nearest => vk::Filter::NEAREST,
+    }
+}
+
+fn get_address_mode(yakui_address_mode: yakui::paint::AddressMode) -> vk::SamplerAddressMode {
+    match yakui_address_mode {
+        yakui::paint::AddressMode::ClampToEdge => vk::SamplerAddressMode::CLAMP_TO_EDGE,
+        yakui::paint::AddressMode::Repeat => vk::SamplerAddressMode::REPEAT,
     }
 }
 

--- a/crates/yakui-wgpu/src/lib.rs
+++ b/crates/yakui-wgpu/src/lib.rs
@@ -133,12 +133,14 @@ impl YakuiWgpu {
         min_filter: wgpu::FilterMode,
         mag_filter: wgpu::FilterMode,
         mipmap_filter: wgpu::FilterMode,
+        address_mode: wgpu::AddressMode,
     ) -> TextureId {
         let index = self.textures.insert(GpuTexture {
             view: view.into(),
             min_filter,
             mag_filter,
             mipmap_filter,
+            address_mode,
         });
         TextureId::User(index.to_bits())
     }
@@ -312,7 +314,7 @@ impl YakuiWgpu {
                 self.vertices.extend(vertices);
                 self.indices.extend(indices);
 
-                let (view, min_filter, mag_filter, mipmap_filter) = call
+                let (view, min_filter, mag_filter, mipmap_filter, address_mode) = call
                     .texture
                     .and_then(|id| match id {
                         TextureId::Managed(managed) => {
@@ -322,6 +324,7 @@ impl YakuiWgpu {
                                 texture.min_filter,
                                 texture.mag_filter,
                                 wgpu::FilterMode::Nearest,
+                                texture.address_mode,
                             ))
                         }
                         TextureId::User(bits) => {
@@ -332,6 +335,7 @@ impl YakuiWgpu {
                                 texture.min_filter,
                                 texture.mag_filter,
                                 texture.mipmap_filter,
+                                texture.address_mode,
                             ))
                         }
                     })
@@ -340,9 +344,12 @@ impl YakuiWgpu {
                         self.default_texture.min_filter,
                         self.default_texture.mag_filter,
                         wgpu::FilterMode::Nearest,
+                        self.default_texture.address_mode,
                     ));
 
-                let sampler = self.samplers.get(min_filter, mag_filter, mipmap_filter);
+                let sampler =
+                    self.samplers
+                        .get(min_filter, mag_filter, mipmap_filter, address_mode);
 
                 let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
                     label: Some("yakui Bind Group"),

--- a/crates/yakui-wgpu/src/samplers.rs
+++ b/crates/yakui-wgpu/src/samplers.rs
@@ -1,28 +1,46 @@
+use std::collections::HashMap;
+
 pub(crate) struct Samplers {
-    nearest_nearest_nearest: wgpu::Sampler,
-    linear_linear_nearest: wgpu::Sampler,
-    nearest_linear_nearest: wgpu::Sampler,
-    linear_nearest_nearest: wgpu::Sampler,
-    nearest_nearest_linear: wgpu::Sampler,
-    linear_linear_linear: wgpu::Sampler,
-    nearest_linear_linear: wgpu::Sampler,
-    linear_nearest_linear: wgpu::Sampler,
+    samplers: HashMap<SamplerKey, wgpu::Sampler>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct SamplerKey {
+    min_filter: wgpu::FilterMode,
+    mag_filter: wgpu::FilterMode,
+    mipmap_filter: wgpu::FilterMode,
+    address_mode: wgpu::AddressMode,
 }
 
 impl Samplers {
     pub fn new(device: &wgpu::Device) -> Self {
+        use wgpu::AddressMode::{ClampToEdge, Repeat};
         use wgpu::FilterMode::{Linear, Nearest};
 
-        Self {
-            nearest_nearest_nearest: sampler(device, Nearest, Nearest, Nearest),
-            linear_linear_nearest: sampler(device, Linear, Linear, Nearest),
-            nearest_linear_nearest: sampler(device, Nearest, Linear, Nearest),
-            linear_nearest_nearest: sampler(device, Linear, Nearest, Nearest),
-            nearest_nearest_linear: sampler(device, Nearest, Nearest, Linear),
-            linear_linear_linear: sampler(device, Linear, Linear, Linear),
-            nearest_linear_linear: sampler(device, Nearest, Linear, Linear),
-            linear_nearest_linear: sampler(device, Linear, Nearest, Linear),
+        let mut samplers = HashMap::new();
+
+        let filter_modes = [Linear, Nearest];
+        let address_modes = [ClampToEdge, Repeat];
+        for min_filter in filter_modes {
+            for mag_filter in filter_modes {
+                for mipmap_filter in filter_modes {
+                    for address_mode in address_modes {
+                        let key = SamplerKey {
+                            min_filter,
+                            mag_filter,
+                            mipmap_filter,
+                            address_mode,
+                        };
+                        samplers.insert(
+                            key,
+                            sampler(device, min_filter, mag_filter, mipmap_filter, address_mode),
+                        );
+                    }
+                }
+            }
         }
+
+        Self { samplers }
     }
 
     pub fn get(
@@ -30,19 +48,16 @@ impl Samplers {
         min: wgpu::FilterMode,
         max: wgpu::FilterMode,
         mipmap: wgpu::FilterMode,
+        address_mode: wgpu::AddressMode,
     ) -> &wgpu::Sampler {
-        use wgpu::FilterMode::{Linear, Nearest};
-
-        match (min, max, mipmap) {
-            (Nearest, Nearest, Nearest) => &self.nearest_nearest_nearest,
-            (Linear, Linear, Nearest) => &self.linear_linear_nearest,
-            (Nearest, Linear, Nearest) => &self.nearest_linear_nearest,
-            (Linear, Nearest, Nearest) => &self.linear_nearest_nearest,
-            (Nearest, Nearest, Linear) => &self.nearest_nearest_linear,
-            (Linear, Linear, Linear) => &self.linear_linear_linear,
-            (Nearest, Linear, Linear) => &self.nearest_linear_linear,
-            (Linear, Nearest, Linear) => &self.linear_nearest_linear,
-        }
+        self.samplers
+            .get(&SamplerKey {
+                min_filter: min,
+                mag_filter: max,
+                mipmap_filter: mipmap,
+                address_mode,
+            })
+            .unwrap()
     }
 }
 
@@ -51,11 +66,14 @@ fn sampler(
     min_filter: wgpu::FilterMode,
     mag_filter: wgpu::FilterMode,
     mipmap_filter: wgpu::FilterMode,
+    address_mode: wgpu::AddressMode,
 ) -> wgpu::Sampler {
     device.create_sampler(&wgpu::SamplerDescriptor {
         mag_filter,
         min_filter,
         mipmap_filter,
+        address_mode_u: address_mode,
+        address_mode_v: address_mode,
         ..Default::default()
     })
 }

--- a/crates/yakui-wgpu/src/texture.rs
+++ b/crates/yakui-wgpu/src/texture.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use {std::sync::Arc, yakui_core::paint::AddressMode};
 
 use glam::UVec2;
 use yakui_core::paint::{Texture, TextureFilter, TextureFormat};
@@ -10,6 +10,7 @@ pub(crate) struct GpuManagedTexture {
     pub view: wgpu::TextureView,
     pub min_filter: wgpu::FilterMode,
     pub mag_filter: wgpu::FilterMode,
+    pub address_mode: wgpu::AddressMode,
 }
 
 pub(crate) struct GpuTexture {
@@ -17,6 +18,7 @@ pub(crate) struct GpuTexture {
     pub min_filter: wgpu::FilterMode,
     pub mag_filter: wgpu::FilterMode,
     pub mipmap_filter: wgpu::FilterMode,
+    pub address_mode: wgpu::AddressMode,
 }
 
 impl GpuManagedTexture {
@@ -54,6 +56,7 @@ impl GpuManagedTexture {
 
         let min_filter = wgpu_filter_mode(texture.min_filter);
         let mag_filter = wgpu_filter_mode(texture.mag_filter);
+        let address_mode = wgpu_address_mode(texture.address_mode);
 
         Self {
             size: texture.size(),
@@ -62,6 +65,7 @@ impl GpuManagedTexture {
             view: gpu_view,
             min_filter,
             mag_filter,
+            address_mode,
         }
     }
 
@@ -120,5 +124,12 @@ fn wgpu_filter_mode(filter: TextureFilter) -> wgpu::FilterMode {
     match filter {
         TextureFilter::Linear => wgpu::FilterMode::Linear,
         TextureFilter::Nearest => wgpu::FilterMode::Nearest,
+    }
+}
+
+fn wgpu_address_mode(address_mode: AddressMode) -> wgpu::AddressMode {
+    match address_mode {
+        AddressMode::ClampToEdge => wgpu::AddressMode::ClampToEdge,
+        AddressMode::Repeat => wgpu::AddressMode::Repeat,
     }
 }


### PR DESCRIPTION
Addresses #175 

Adds

```rust
#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
pub enum AddressMode {
    /// Clamp to the edge of the texture
    ClampToEdge,

    /// Repeat the texture
    Repeat,
}
```

and adds it to

```rust
pub struct Texture {
    // [...]

    /// How to handle texture addressing
    pub address_mode: AddressMode,
}
```

and implements setting the address mode in `yakui-wgpu` and `yakui-vulkan`