### PR TITLE
make the TextGlobalState public

### DIFF
--- a/crates/yakui-widgets/src/lib.rs
+++ b/crates/yakui-widgets/src/lib.rs
@@ -5,13 +5,13 @@
 )]
 
 mod ignore_debug;
-mod text_renderer;
 
 pub mod colors;
 pub mod font;
 pub mod shapes;
 pub mod shorthand;
 pub mod style;
+pub mod text_renderer;
 pub mod util;
 pub mod widgets;
 

--- a/crates/yakui/src/lib.rs
+++ b/crates/yakui/src/lib.rs
@@ -9,4 +9,5 @@ pub use yakui_widgets::font;
 pub use yakui_widgets::shapes;
 pub use yakui_widgets::shorthand::*;
 pub use yakui_widgets::style;
+pub use yakui_widgets::text_renderer;
 pub use yakui_widgets::util;


### PR DESCRIPTION
Implementing `RenderText` entirely in user-land is desirable for text effects. Although many advanced users might use their *own* equivalent of `TextGlobalState`, making this public can help that process along.

Moreover, morally, `RenderText` (along with all the widgets) should be fully implementable in user-land.