### PR TITLE
added must-use to widgets

### DIFF
--- a/crates/yakui-widgets/src/widgets/align.rs
+++ b/crates/yakui-widgets/src/widgets/align.rs
@@ -34,6 +34,7 @@ Align::new(yakui::Alignment::TOP_RIGHT).show(|| {
 */
 #[derive(Debug, Clone)]
 #[non_exhaustive]
+#[must_use = "yakui widgets do nothing if you don't `show` them"]
 pub struct Align {
     pub alignment: Alignment,
 }

--- a/crates/yakui-widgets/src/widgets/button.rs
+++ b/crates/yakui-widgets/src/widgets/button.rs
@@ -28,6 +28,7 @@ if yakui::button("Hello").clicked {
 */
 #[derive(Debug)]
 #[non_exhaustive]
+#[must_use = "yakui widgets do nothing if you don't `show` them"]
 pub struct Button {
     pub text: Cow<'static, str>,
     pub padding: Pad,

--- a/crates/yakui-widgets/src/widgets/canvas.rs
+++ b/crates/yakui-widgets/src/widgets/canvas.rs
@@ -12,6 +12,7 @@ Allows the user to draw arbitrary graphics in a region.
 Responds with [CanvasResponse].
 */
 #[derive(Debug)]
+#[must_use = "yakui widgets do nothing if you don't `show` them"]
 pub struct Canvas {
     draw: IgnoreDebug<Option<DrawCallback>>,
 }

--- a/crates/yakui-widgets/src/widgets/checkbox.rs
+++ b/crates/yakui-widgets/src/widgets/checkbox.rs
@@ -25,6 +25,7 @@ value = yakui::checkbox(value).checked;
 */
 #[derive(Debug)]
 #[non_exhaustive]
+#[must_use = "yakui widgets do nothing if you don't `show` them"]
 pub struct Checkbox {
     pub checked: bool,
 }

--- a/crates/yakui-widgets/src/widgets/circle.rs
+++ b/crates/yakui-widgets/src/widgets/circle.rs
@@ -12,6 +12,7 @@ Responds with [CircleResponse].
 */
 #[derive(Debug, Clone)]
 #[non_exhaustive]
+#[must_use = "yakui widgets do nothing if you don't `show` them"]
 pub struct Circle {
     pub color: Color,
     pub min_radius: f32,

--- a/crates/yakui-widgets/src/widgets/colored_box.rs
+++ b/crates/yakui-widgets/src/widgets/colored_box.rs
@@ -12,6 +12,7 @@ Responds with [ColoredBoxResponse].
 */
 #[derive(Debug, Clone)]
 #[non_exhaustive]
+#[must_use = "yakui widgets do nothing if you don't `show` them"]
 pub struct ColoredBox {
     pub color: Color,
     pub min_size: Vec2,

--- a/crates/yakui-widgets/src/widgets/constrained_box.rs
+++ b/crates/yakui-widgets/src/widgets/constrained_box.rs
@@ -11,6 +11,7 @@ Responds with [ConstrainedBoxResponse].
 */
 #[derive(Debug, Clone)]
 #[non_exhaustive]
+#[must_use = "yakui widgets do nothing if you don't `show` them"]
 pub struct ConstrainedBox {
     pub constraints: Constraints,
 }

--- a/crates/yakui-widgets/src/widgets/count_grid.rs
+++ b/crates/yakui-widgets/src/widgets/count_grid.rs
@@ -28,6 +28,7 @@ Responds with [CountGridResponse].
 */
 #[derive(Debug, Clone)]
 #[non_exhaustive]
+#[must_use = "yakui widgets do nothing if you don't `show` them"]
 pub struct CountGrid {
     pub direction: Direction,
     pub cross_axis_count: usize,

--- a/crates/yakui-widgets/src/widgets/cutout.rs
+++ b/crates/yakui-widgets/src/widgets/cutout.rs
@@ -13,6 +13,7 @@ Responds with [CutOutResponse].
 */
 #[derive(Debug, Clone)]
 #[non_exhaustive]
+#[must_use = "yakui widgets do nothing if you don't `show` them"]
 pub struct CutOut {
     pub image: Option<TextureId>,
     pub image_color: Color,

--- a/crates/yakui-widgets/src/widgets/divider.rs
+++ b/crates/yakui-widgets/src/widgets/divider.rs
@@ -8,6 +8,7 @@ use yakui_core::Response;
 /// Responds with [DividerResponse].
 #[derive(Debug)]
 #[non_exhaustive]
+#[must_use = "yakui widgets do nothing if you don't `show` them"]
 pub struct Divider {
     /// The color of the divider.
     pub color: Color,

--- a/crates/yakui-widgets/src/widgets/draggable.rs
+++ b/crates/yakui-widgets/src/widgets/draggable.rs
@@ -8,6 +8,7 @@ use crate::util::widget_children;
 
 #[derive(Debug)]
 #[non_exhaustive]
+#[must_use = "yakui widgets do nothing if you don't `show` them"]
 pub struct Draggable {}
 
 impl Draggable {

--- a/crates/yakui-widgets/src/widgets/flexible.rs
+++ b/crates/yakui-widgets/src/widgets/flexible.rs
@@ -23,6 +23,7 @@ yakui::flexible(2, || {
 */
 #[derive(Debug)]
 #[non_exhaustive]
+#[must_use = "yakui widgets do nothing if you don't `show` them"]
 pub struct Flexible {
     pub flex: u32,
     pub fit: FlexFit,

--- a/crates/yakui-widgets/src/widgets/image.rs
+++ b/crates/yakui-widgets/src/widgets/image.rs
@@ -12,6 +12,7 @@ Responds with [ImageResponse].
 */
 #[derive(Debug, Clone)]
 #[non_exhaustive]
+#[must_use = "yakui widgets do nothing if you don't `show` them"]
 pub struct Image {
     pub image: Option<TextureId>,
     pub size: Vec2,

--- a/crates/yakui-widgets/src/widgets/layer.rs
+++ b/crates/yakui-widgets/src/widgets/layer.rs
@@ -13,6 +13,7 @@ applied to layers.
 */
 #[derive(Debug, Clone)]
 #[non_exhaustive]
+#[must_use = "yakui widgets do nothing if you don't `show` them"]
 pub struct Layer {}
 
 impl Layer {

--- a/crates/yakui-widgets/src/widgets/list.rs
+++ b/crates/yakui-widgets/src/widgets/list.rs
@@ -27,6 +27,7 @@ yakui::row(|| {
 */
 #[derive(Debug, Clone)]
 #[non_exhaustive]
+#[must_use = "yakui widgets do nothing if you don't `show` them"]
 pub struct List {
     pub direction: Direction,
     /// Added space at the end of each item.

--- a/crates/yakui-widgets/src/widgets/max_width.rs
+++ b/crates/yakui-widgets/src/widgets/max_width.rs
@@ -11,6 +11,7 @@ Responds with [MaxWidthResponse].
 */
 #[derive(Debug, Clone)]
 #[non_exhaustive]
+#[must_use = "yakui widgets do nothing if you don't `show` them"]
 pub struct MaxWidth {
     pub max_width: f32,
 }

--- a/crates/yakui-widgets/src/widgets/nineslice.rs
+++ b/crates/yakui-widgets/src/widgets/nineslice.rs
@@ -8,6 +8,7 @@ use yakui_core::{
 use crate::{shorthand::pad, util::widget_children, widgets::pad::Pad};
 
 #[derive(Debug)]
+#[must_use = "yakui widgets do nothing if you don't `show` them"]
 pub struct NineSlice {
     texture: ManagedTextureId,
     /// Texture margins in pixels around the central NineSlice region, before

--- a/crates/yakui-widgets/src/widgets/offset.rs
+++ b/crates/yakui-widgets/src/widgets/offset.rs
@@ -9,6 +9,7 @@ Offsets its child by the given number of logical pixels.
 */
 #[derive(Debug, Clone)]
 #[non_exhaustive]
+#[must_use = "yakui widgets do nothing if you don't `show` them"]
 pub struct Offset {
     pub offset: Vec2,
 }

--- a/crates/yakui-widgets/src/widgets/opaque.rs
+++ b/crates/yakui-widgets/src/widgets/opaque.rs
@@ -11,6 +11,7 @@ that don't want mouse input to go through them.
 */
 #[derive(Debug, Clone)]
 #[non_exhaustive]
+#[must_use = "yakui widgets do nothing if you don't `show` them"]
 pub struct Opaque {}
 
 impl Opaque {

--- a/crates/yakui-widgets/src/widgets/pad.rs
+++ b/crates/yakui-widgets/src/widgets/pad.rs
@@ -11,6 +11,7 @@ Responds with [PadResponse].
 */
 #[derive(Debug, Clone, Copy)]
 #[non_exhaustive]
+#[must_use = "yakui widgets do nothing if you don't `show` them"]
 pub struct Pad {
     pub left: f32,
     pub right: f32,

--- a/crates/yakui-widgets/src/widgets/panel.rs
+++ b/crates/yakui-widgets/src/widgets/panel.rs
@@ -17,6 +17,7 @@ const _RESIZE_HANDLE_WIDTH: f32 = 6.0;
 /// detection and movement within a single widget?
 #[derive(Debug)]
 #[non_exhaustive]
+#[must_use = "yakui widgets do nothing if you don't `show` them"]
 pub struct Panel {
     pub kind: PanelKind,
 }

--- a/crates/yakui-widgets/src/widgets/reflow.rs
+++ b/crates/yakui-widgets/src/widgets/reflow.rs
@@ -10,6 +10,7 @@ or table layouts.
 */
 #[derive(Debug, Clone)]
 #[non_exhaustive]
+#[must_use = "yakui widgets do nothing if you don't `show` them"]
 pub struct Reflow {
     pub anchor: Alignment,
     pub pivot: Pivot,

--- a/crates/yakui-widgets/src/widgets/render_text.rs
+++ b/crates/yakui-widgets/src/widgets/render_text.rs
@@ -22,6 +22,7 @@ supports features like padding.
 */
 #[derive(Debug)]
 #[non_exhaustive]
+#[must_use = "yakui widgets do nothing if you don't `show` them"]
 pub struct RenderText {
     pub text: Cow<'static, str>,
     pub style: TextStyle,

--- a/crates/yakui-widgets/src/widgets/render_textbox.rs
+++ b/crates/yakui-widgets/src/widgets/render_textbox.rs
@@ -21,6 +21,7 @@ Responds with [RenderTextBoxResponse].
 */
 #[derive(Debug, Clone)]
 #[non_exhaustive]
+#[must_use = "yakui widgets do nothing if you don't `show` them"]
 pub struct RenderTextBox {
     pub text: String,
     pub style: TextStyle,

--- a/crates/yakui-widgets/src/widgets/round_rect.rs
+++ b/crates/yakui-widgets/src/widgets/round_rect.rs
@@ -12,6 +12,7 @@ Responds with [RoundRectResponse].
 */
 #[derive(Debug, Clone)]
 #[non_exhaustive]
+#[must_use = "yakui widgets do nothing if you don't `show` them"]
 pub struct RoundRect {
     pub radius: f32,
     pub color: Color,

--- a/crates/yakui-widgets/src/widgets/scrollable.rs
+++ b/crates/yakui-widgets/src/widgets/scrollable.rs
@@ -9,6 +9,7 @@ use crate::util::widget_children;
 
 #[derive(Debug)]
 #[non_exhaustive]
+#[must_use = "yakui widgets do nothing if you don't `show` them"]
 pub struct Scrollable {
     pub direction: Option<ScrollDirection>,
 }

--- a/crates/yakui-widgets/src/widgets/slider.rs
+++ b/crates/yakui-widgets/src/widgets/slider.rs
@@ -18,6 +18,7 @@ const TOTAL_HEIGHT: f32 = KNOB_SIZE * 1.5;
 
 #[derive(Debug)]
 #[non_exhaustive]
+#[must_use = "yakui widgets do nothing if you don't `show` them"]
 pub struct Slider {
     pub value: f64,
     pub min: f64,

--- a/crates/yakui-widgets/src/widgets/spacer.rs
+++ b/crates/yakui-widgets/src/widgets/spacer.rs
@@ -11,6 +11,7 @@ use crate::util::widget;
 /// Responds with [SpacerResponse].
 #[derive(Debug)]
 #[non_exhaustive]
+#[must_use = "yakui widgets do nothing if you don't `show` them"]
 pub struct Spacer {
     pub flex: u32,
 }

--- a/crates/yakui-widgets/src/widgets/state.rs
+++ b/crates/yakui-widgets/src/widgets/state.rs
@@ -7,6 +7,7 @@ use yakui_core::Response;
 
 use crate::util;
 
+#[must_use = "yakui widgets do nothing if you don't `show` them"]
 pub struct State<T> {
     default: Box<dyn FnOnce() -> T>,
 }

--- a/crates/yakui-widgets/src/widgets/text.rs
+++ b/crates/yakui-widgets/src/widgets/text.rs
@@ -29,6 +29,7 @@ text.show();
 */
 #[derive(Debug)]
 #[non_exhaustive]
+#[must_use = "yakui widgets do nothing if you don't `show` them"]
 pub struct Text {
     pub text: Cow<'static, str>,
     pub style: TextStyle,

--- a/crates/yakui-widgets/src/widgets/textbox.rs
+++ b/crates/yakui-widgets/src/widgets/textbox.rs
@@ -24,6 +24,7 @@ Responds with [TextBoxResponse].
 */
 #[derive(Debug, Clone)]
 #[non_exhaustive]
+#[must_use = "yakui widgets do nothing if you don't `show` them"]
 pub struct TextBox {
     pub text: String,
     pub style: TextStyle,

--- a/crates/yakui-widgets/src/widgets/unconstrained_box.rs
+++ b/crates/yakui-widgets/src/widgets/unconstrained_box.rs
@@ -11,6 +11,7 @@ Responds with [UnconstrainedBoxResponse].
 */
 #[derive(Debug, Clone)]
 #[non_exhaustive]
+#[must_use = "yakui widgets do nothing if you don't `show` them"]
 pub struct UnconstrainedBox {
     pub constrain_x: bool,
     pub constrain_y: bool,

--- a/crates/yakui-widgets/src/widgets/window.rs
+++ b/crates/yakui-widgets/src/widgets/window.rs
@@ -13,6 +13,7 @@ A floating window within the application.
 
 Responds with [WindowResponse].
 */
+#[must_use = "yakui widgets do nothing if you don't `show` them"]
 pub struct Window {
     pub initial_size: Vec2,
     children: Option<Box<dyn Fn()>>,


### PR DESCRIPTION
yakui widgets don't do anything unless `show` is called on them. In practice, adding this somewhat solidifies this library's usage of `show` rather than `yakui::utils::widget` or variant, but I think this is a good pattern the lib does, and naming it isn't a huge deal IMO.