### PR TITLE
min-size, fixes 199

### DIFF
--- a/crates/yakui-widgets/src/widgets/align.rs
+++ b/crates/yakui-widgets/src/widgets/align.rs
@@ -82,9 +82,7 @@ impl Widget for AlignWidget {
         // enforced by the incoming constraints.
         let constraints = Constraints::loose(input.max);
 
-        let mut self_size = if input.max.is_finite() {
-            input.max
-        } else if input.min.is_finite() {
+        let mut self_size = if input.min.is_finite() {
             input.min
         } else {
             Vec2::ZERO

--- a/crates/yakui-widgets/src/widgets/list.rs
+++ b/crates/yakui-widgets/src/widgets/list.rs
@@ -49,7 +49,7 @@ impl List {
         Self {
             direction,
             item_spacing: 0.0,
-            main_axis_size: MainAxisSize::Max,
+            main_axis_size: MainAxisSize::Min,
             main_axis_alignment: MainAxisAlignment::Start,
             cross_axis_alignment: CrossAxisAlignment::Start,
         }

--- a/crates/yakui-widgets/src/widgets/offset.rs
+++ b/crates/yakui-widgets/src/widgets/offset.rs
@@ -51,9 +51,7 @@ impl Widget for OffsetWidget {
         // enforced by the incoming constraints.
         let constraints = Constraints::loose(input.max);
 
-        let mut self_size = if input.max.is_finite() {
-            input.max
-        } else if input.min.is_finite() {
+        let mut self_size = if input.min.is_finite() {
             input.min
         } else {
             Vec2::ZERO


### PR DESCRIPTION
This makes the default size of list (and Align and Offset) to be Minimum rather than Maximum. In general, Maximum seems to be the wrong answer almost always.

Adds a "Maximize" widget which forces its child to be at maximum size (not yet done).
