### PR TITLE
recreate widgets when callsite changes, and keep track of callsite with #[track_caller]

### DIFF
--- a/crates/yakui-core/src/dom/mod.rs
+++ b/crates/yakui-core/src/dom/mod.rs
@@ -234,15 +234,11 @@ impl Dom {
             let is_type_different = widget.as_ref().type_id() != TypeId::of::<T>();
             let is_callsite_different = callsite != Location::caller();
 
-            if is_type_different {
+            if is_callsite_different || is_type_different {
                 widget = Box::new(T::new());
             }
 
             let widget = widget.downcast_mut::<T>().unwrap();
-            // If the Type is different, it'd already be recreated. Let's avoid calling T::new twice.
-            if is_callsite_different && !is_type_different {
-                *widget = T::new();
-            }
 
             widget.update(props)
         };

--- a/crates/yakui-widgets/src/shorthand.rs
+++ b/crates/yakui-widgets/src/shorthand.rs
@@ -20,41 +20,49 @@ use crate::widgets::{
 };
 
 /// See [List].
+#[track_caller]
 pub fn column<F: FnOnce()>(children: F) -> Response<ListResponse> {
     List::column().show(children)
 }
 
 /// See [List].
+#[track_caller]
 pub fn row<F: FnOnce()>(children: F) -> Response<ListResponse> {
     List::row().show(children)
 }
 
 /// See [CountGrid].
+#[track_caller]
 pub fn countgrid_column<F: FnOnce()>(n_columns: usize, children: F) -> Response<ListResponse> {
     CountGrid::col(n_columns).show(children)
 }
 
 /// See [CountGrid].
+#[track_caller]
 pub fn countgrid_row<F: FnOnce()>(n_rows: usize, children: F) -> Response<ListResponse> {
     CountGrid::row(n_rows).show(children)
 }
 
 /// See [Align].
+#[track_caller]
 pub fn center<F: FnOnce()>(children: F) -> Response<AlignResponse> {
     Align::center().show(children)
 }
 
 /// See [Align].
+#[track_caller]
 pub fn align<F: FnOnce()>(alignment: Alignment, children: F) -> Response<AlignResponse> {
     Align::new(alignment).show(children)
 }
 
 /// See [Button].
+#[track_caller]
 pub fn button<S: Into<Cow<'static, str>>>(text: S) -> Response<ButtonResponse> {
     Button::styled(text.into()).show()
 }
 
 /// See [Circle].
+#[track_caller]
 pub fn colored_circle<S: Into<f32>>(color: Color, size: S) -> Response<CircleResponse> {
     let mut circle = Circle::new();
     circle.min_radius = size.into();
@@ -63,11 +71,13 @@ pub fn colored_circle<S: Into<f32>>(color: Color, size: S) -> Response<CircleRes
 }
 
 /// See [ColoredBox].
+#[track_caller]
 pub fn colored_box<S: Into<Vec2>>(color: Color, size: S) -> Response<ColoredBoxResponse> {
     ColoredBox::sized(color, size.into()).show()
 }
 
 /// See [ColoredBox].
+#[track_caller]
 pub fn colored_box_container<F: FnOnce()>(
     color: Color,
     children: F,
@@ -76,6 +86,7 @@ pub fn colored_box_container<F: FnOnce()>(
 }
 
 /// See [Image].
+#[track_caller]
 pub fn image<I, S>(image: I, size: S) -> Response<ImageResponse>
 where
     I: Into<TextureId>,
@@ -85,36 +96,43 @@ where
 }
 
 /// See [Pad].
+#[track_caller]
 pub fn pad<F: FnOnce()>(padding: Pad, children: F) -> Response<PadResponse> {
     padding.show(children)
 }
 
 /// See [Text].
+#[track_caller]
 pub fn text<S: Into<Cow<'static, str>>>(size: f32, text: S) -> Response<TextResponse> {
     Text::new(size, text.into()).show()
 }
 
 /// See [Text].
+#[track_caller]
 pub fn label<S: Into<Cow<'static, str>>>(text: S) -> Response<TextResponse> {
     Text::label(text.into()).show()
 }
 
 /// See [TextBox].
+#[track_caller]
 pub fn textbox<S: Into<String>>(text: S) -> Response<TextBoxResponse> {
     TextBox::new(text.into()).show()
 }
 
 /// See [Flexible].
+#[track_caller]
 pub fn flexible<F: FnOnce()>(flex: u32, children: F) -> Response<FlexibleResponse> {
     Flexible::new(flex).show(children)
 }
 
 /// See [Flexible].
+#[track_caller]
 pub fn expanded<F: FnOnce()>(children: F) -> Response<FlexibleResponse> {
     Flexible::expanded().show(children)
 }
 
 /// See [ConstrainedBox].
+#[track_caller]
 pub fn constrained<F: FnOnce()>(
     constraints: Constraints,
     children: F,
@@ -123,21 +141,25 @@ pub fn constrained<F: FnOnce()>(
 }
 
 /// See [Checkbox].
+#[track_caller]
 pub fn checkbox(checked: bool) -> Response<CheckboxResponse> {
     Checkbox::new(checked).show()
 }
 
 /// See [Offset].
+#[track_caller]
 pub fn offset<F: FnOnce()>(offset: Vec2, children: F) -> Response<OffsetResponse> {
     Offset::new(offset).show(children)
 }
 
 /// See [Draggable].
+#[track_caller]
 pub fn draggable<F: FnOnce()>(children: F) -> Response<DraggableResponse> {
     Draggable::new().show(children)
 }
 
 /// See [NineSlice].
+#[track_caller]
 pub fn nineslice(
     texture: ManagedTextureId,
     margins: Pad,
@@ -148,26 +170,31 @@ pub fn nineslice(
 }
 
 /// See [Divider].
+#[track_caller]
 pub fn divider(color: Color, height: f32, thickness: f32) -> Response<DividerResponse> {
     Divider::new(color, height, thickness).show()
 }
 
 /// See [Spacer].
+#[track_caller]
 pub fn spacer(flex: u32) -> Response<FlexibleResponse> {
     Spacer::new(flex).show()
 }
 
 /// See [Scrollable].
+#[track_caller]
 pub fn scroll_vertical(children: impl FnOnce()) -> Response<ScrollableResponse> {
     Scrollable::vertical().show(children)
 }
 
 /// See [Slider].
+#[track_caller]
 pub fn slider(value: f64, min: f64, max: f64) -> Response<SliderResponse> {
     Slider::new(value, min, max).show()
 }
 
 /// See [Reflow].
+#[track_caller]
 pub fn reflow(
     anchor: Alignment,
     pivot: Pivot,
@@ -178,25 +205,30 @@ pub fn reflow(
 }
 
 /// See [Opaque].
+#[track_caller]
 pub fn opaque(children: impl FnOnce()) -> Response<OpaqueResponse> {
     Opaque::new().show(children)
 }
 
 /// See [Canvas].
+#[track_caller]
 pub fn canvas(paint: impl Fn(&mut PaintContext<'_>) + 'static) -> Response<CanvasResponse> {
     Canvas::new(paint).show()
 }
 
 /// See [MaxWidth].
+#[track_caller]
 pub fn max_width(max_width: f32, children: impl FnOnce()) -> Response<MaxWidthResponse> {
     MaxWidth::new(max_width).show(children)
 }
 
 /// See [Stack].
+#[track_caller]
 pub fn stack(children: impl FnOnce()) -> Response<StackResponse> {
     Stack::new().show(children)
 }
 
+#[track_caller]
 pub fn use_state<F, T: 'static>(default: F) -> Response<StateResponse<T>>
 where
     F: FnOnce() -> T + 'static,

--- a/crates/yakui-widgets/src/util.rs
+++ b/crates/yakui-widgets/src/util.rs
@@ -5,6 +5,7 @@ use yakui_core::widget::Widget;
 use yakui_core::Response;
 
 /// Show a widget with the given children and props.
+#[track_caller]
 pub fn widget_children<T, F>(children: F, props: T::Props<'_>) -> Response<T::Response>
 where
     T: Widget,
@@ -18,6 +19,7 @@ where
 }
 
 /// Show a widget with the given props.
+#[track_caller]
 pub fn widget<T>(props: T::Props<'_>) -> Response<T::Response>
 where
     T: Widget,

--- a/crates/yakui-widgets/src/widgets/align.rs
+++ b/crates/yakui-widgets/src/widgets/align.rs
@@ -49,6 +49,7 @@ impl Align {
         }
     }
 
+    #[track_caller]
     pub fn show<F: FnOnce()>(self, children: F) -> Response<AlignResponse> {
         widget_children::<AlignWidget, F>(children, self)
     }

--- a/crates/yakui-widgets/src/widgets/button.rs
+++ b/crates/yakui-widgets/src/widgets/button.rs
@@ -107,6 +107,7 @@ impl Button {
         }
     }
 
+    #[track_caller]
     pub fn show(self) -> Response<ButtonResponse> {
         widget::<ButtonWidget>(self)
     }

--- a/crates/yakui-widgets/src/widgets/canvas.rs
+++ b/crates/yakui-widgets/src/widgets/canvas.rs
@@ -24,10 +24,12 @@ impl Canvas {
         }
     }
 
+    #[track_caller]
     pub fn show(self) -> Response<CanvasResponse> {
         widget::<CanvasWidget>(self)
     }
 
+    #[track_caller]
     pub fn show_children<F: FnOnce()>(self, children: F) -> Response<CanvasResponse> {
         widget_children::<CanvasWidget, F>(children, self)
     }

--- a/crates/yakui-widgets/src/widgets/checkbox.rs
+++ b/crates/yakui-widgets/src/widgets/checkbox.rs
@@ -34,6 +34,7 @@ impl Checkbox {
         Self { checked }
     }
 
+    #[track_caller]
     pub fn show(self) -> Response<CheckboxResponse> {
         crate::util::widget::<CheckboxWidget>(self)
     }

--- a/crates/yakui-widgets/src/widgets/circle.rs
+++ b/crates/yakui-widgets/src/widgets/circle.rs
@@ -30,10 +30,12 @@ impl Circle {
         }
     }
 
+    #[track_caller]
     pub fn show(self) -> Response<CircleResponse> {
         widget::<CircleWidget>(self)
     }
 
+    #[track_caller]
     pub fn show_children<F: FnOnce()>(self, children: F) -> Response<CircleResponse> {
         widget_children::<CircleWidget, F>(children, self)
     }

--- a/crates/yakui-widgets/src/widgets/colored_box.rs
+++ b/crates/yakui-widgets/src/widgets/colored_box.rs
@@ -45,10 +45,12 @@ impl ColoredBox {
         }
     }
 
+    #[track_caller]
     pub fn show(self) -> Response<ColoredBoxResponse> {
         widget::<ColoredBoxWidget>(self)
     }
 
+    #[track_caller]
     pub fn show_children<F: FnOnce()>(self, children: F) -> Response<ColoredBoxResponse> {
         widget_children::<ColoredBoxWidget, F>(children, self)
     }

--- a/crates/yakui-widgets/src/widgets/constrained_box.rs
+++ b/crates/yakui-widgets/src/widgets/constrained_box.rs
@@ -20,6 +20,7 @@ impl ConstrainedBox {
         Self { constraints }
     }
 
+    #[track_caller]
     pub fn show<F: FnOnce()>(self, children: F) -> Response<ConstrainedBoxResponse> {
         widget_children::<ConstrainedBoxWidget, F>(children, self)
     }

--- a/crates/yakui-widgets/src/widgets/count_grid.rs
+++ b/crates/yakui-widgets/src/widgets/count_grid.rs
@@ -82,6 +82,7 @@ impl CountGrid {
     /// 2 3
     /// 4 5
     /// ```
+    #[track_caller]
     pub fn show<F: FnOnce()>(self, children: F) -> Response<CountGridResponse> {
         widget_children::<CountGridWidget, F>(children, self)
     }

--- a/crates/yakui-widgets/src/widgets/cutout.rs
+++ b/crates/yakui-widgets/src/widgets/cutout.rs
@@ -43,10 +43,12 @@ impl CutOut {
         }
     }
 
+    #[track_caller]
     pub fn show(self) -> Response<CutOutResponse> {
         widget::<CutOutWidget>(self)
     }
 
+    #[track_caller]
     pub fn show_children<F: FnOnce()>(self, children: F) -> Response<CutOutResponse> {
         widget_children::<CutOutWidget, F>(children, self)
     }

--- a/crates/yakui-widgets/src/widgets/divider.rs
+++ b/crates/yakui-widgets/src/widgets/divider.rs
@@ -43,6 +43,7 @@ impl Divider {
         }
     }
 
+    #[track_caller]
     pub fn show(self) -> Response<DividerResponse> {
         crate::util::widget::<DividerWidget>(self)
     }

--- a/crates/yakui-widgets/src/widgets/draggable.rs
+++ b/crates/yakui-widgets/src/widgets/draggable.rs
@@ -15,6 +15,7 @@ impl Draggable {
         Draggable {}
     }
 
+    #[track_caller]
     pub fn show<F: FnOnce()>(self, children: F) -> Response<DraggableResponse> {
         widget_children::<DraggableWidget, F>(children, self)
     }

--- a/crates/yakui-widgets/src/widgets/flexible.rs
+++ b/crates/yakui-widgets/src/widgets/flexible.rs
@@ -43,6 +43,7 @@ impl Flexible {
         }
     }
 
+    #[track_caller]
     pub fn show<F: FnOnce()>(self, children: F) -> Response<FlexibleResponse> {
         widget_children::<FlexibleWidget, F>(children, self)
     }

--- a/crates/yakui-widgets/src/widgets/image.rs
+++ b/crates/yakui-widgets/src/widgets/image.rs
@@ -45,6 +45,7 @@ impl Image {
         }
     }
 
+    #[track_caller]
     pub fn show(self) -> Response<ImageResponse> {
         widget::<ImageWidget>(self)
     }

--- a/crates/yakui-widgets/src/widgets/layer.rs
+++ b/crates/yakui-widgets/src/widgets/layer.rs
@@ -20,6 +20,7 @@ impl Layer {
         Self {}
     }
 
+    #[track_caller]
     pub fn show<F: FnOnce()>(self, children: F) -> Response<LayerResponse> {
         widget_children::<LayerWidget, F>(children, self)
     }

--- a/crates/yakui-widgets/src/widgets/list.rs
+++ b/crates/yakui-widgets/src/widgets/list.rs
@@ -63,6 +63,7 @@ impl List {
         Self::new(Direction::Right)
     }
 
+    #[track_caller]
     pub fn show<F: FnOnce()>(self, children: F) -> Response<ListResponse> {
         widget_children::<ListWidget, F>(children, self)
     }

--- a/crates/yakui-widgets/src/widgets/max_width.rs
+++ b/crates/yakui-widgets/src/widgets/max_width.rs
@@ -20,6 +20,7 @@ impl MaxWidth {
         Self { max_width }
     }
 
+    #[track_caller]
     pub fn show<F: FnOnce()>(self, children: F) -> Response<MaxWidthResponse> {
         widget_children::<MaxWidthWidget, F>(children, self)
     }

--- a/crates/yakui-widgets/src/widgets/nineslice.rs
+++ b/crates/yakui-widgets/src/widgets/nineslice.rs
@@ -34,6 +34,7 @@ impl NineSlice {
         }
     }
 
+    #[track_caller]
     pub fn show(self, children: impl FnOnce()) -> Response<()> {
         let scaled_margins = {
             let mut m = self.margins;

--- a/crates/yakui-widgets/src/widgets/offset.rs
+++ b/crates/yakui-widgets/src/widgets/offset.rs
@@ -18,6 +18,7 @@ impl Offset {
         Self { offset }
     }
 
+    #[track_caller]
     pub fn show<F: FnOnce()>(self, children: F) -> Response<OffsetResponse> {
         widget_children::<OffsetWidget, F>(children, self)
     }

--- a/crates/yakui-widgets/src/widgets/opaque.rs
+++ b/crates/yakui-widgets/src/widgets/opaque.rs
@@ -18,6 +18,7 @@ impl Opaque {
         Self {}
     }
 
+    #[track_caller]
     pub fn show<F: FnOnce()>(self, children: F) -> Response<OpaqueResponse> {
         widget_children::<OpaqueWidget, F>(children, self)
     }

--- a/crates/yakui-widgets/src/widgets/pad.rs
+++ b/crates/yakui-widgets/src/widgets/pad.rs
@@ -61,6 +61,7 @@ impl Pad {
         Vec2::new(self.left, self.top)
     }
 
+    #[track_caller]
     pub fn show<F: FnOnce()>(self, children: F) -> Response<PadResponse> {
         widget_children::<PadWidget, F>(children, self)
     }

--- a/crates/yakui-widgets/src/widgets/panel.rs
+++ b/crates/yakui-widgets/src/widgets/panel.rs
@@ -40,6 +40,7 @@ impl Panel {
         }
     }
 
+    #[track_caller]
     pub fn show<F: FnOnce()>(self, children: F) -> Response<PanelResponse> {
         widget_children::<PanelWidget, F>(children, self)
     }

--- a/crates/yakui-widgets/src/widgets/reflow.rs
+++ b/crates/yakui-widgets/src/widgets/reflow.rs
@@ -25,6 +25,7 @@ impl Reflow {
         }
     }
 
+    #[track_caller]
     pub fn show<F: FnOnce()>(self, children: F) -> Response<ReflowResponse> {
         widget_children::<ReflowWidget, F>(children, self)
     }

--- a/crates/yakui-widgets/src/widgets/render_text.rs
+++ b/crates/yakui-widgets/src/widgets/render_text.rs
@@ -42,10 +42,12 @@ impl RenderText {
         }
     }
 
+    #[track_caller]
     pub fn show(self) -> Response<RenderTextResponse> {
         Self::show_with_scroll(self, None)
     }
 
+    #[track_caller]
     pub fn show_with_scroll(
         self,
         scroll: Option<cosmic_text::Scroll>,

--- a/crates/yakui-widgets/src/widgets/round_rect.rs
+++ b/crates/yakui-widgets/src/widgets/round_rect.rs
@@ -33,10 +33,12 @@ impl RoundRect {
         }
     }
 
+    #[track_caller]
     pub fn show(self) -> Response<RoundRectResponse> {
         widget::<RoundRectWidget>(self)
     }
 
+    #[track_caller]
     pub fn show_children<F: FnOnce()>(self, children: F) -> Response<RoundRectResponse> {
         widget_children::<RoundRectWidget, F>(children, self)
     }

--- a/crates/yakui-widgets/src/widgets/scoped.rs
+++ b/crates/yakui-widgets/src/widgets/scoped.rs
@@ -13,6 +13,7 @@ impl<T: 'static> Scope<T> {
         Self { value }
     }
 
+    #[track_caller]
     pub fn show(self, children: impl FnOnce()) -> Response<ScopeResponse> {
         let dom = context::dom();
         let res = dom.begin_widget::<ScopeWidget>(());

--- a/crates/yakui-widgets/src/widgets/scrollable.rs
+++ b/crates/yakui-widgets/src/widgets/scrollable.rs
@@ -24,6 +24,7 @@ impl Scrollable {
         }
     }
 
+    #[track_caller]
     pub fn show<F: FnOnce()>(self, children: F) -> Response<ScrollableResponse> {
         widget_children::<ScrollableWidget, F>(children, self)
     }

--- a/crates/yakui-widgets/src/widgets/slider.rs
+++ b/crates/yakui-widgets/src/widgets/slider.rs
@@ -42,6 +42,7 @@ impl Slider {
         }
     }
 
+    #[track_caller]
     pub fn show(self) -> Response<SliderResponse> {
         util::widget::<SliderWidget>(self)
     }

--- a/crates/yakui-widgets/src/widgets/spacer.rs
+++ b/crates/yakui-widgets/src/widgets/spacer.rs
@@ -20,6 +20,7 @@ impl Spacer {
         Self { flex: flex.max(1) }
     }
 
+    #[track_caller]
     pub fn show(self) -> Response<SpacerResponse> {
         widget::<SpacerWidget>(self)
     }

--- a/crates/yakui-widgets/src/widgets/stack.rs
+++ b/crates/yakui-widgets/src/widgets/stack.rs
@@ -36,6 +36,7 @@ impl Stack {
     }
 
     /// Shows the [Stack] along with its children.
+    #[track_caller]
     pub fn show<F: FnOnce()>(self, children: F) -> Response<StackResponse> {
         widget_children::<StackWidget, F>(children, self)
     }

--- a/crates/yakui-widgets/src/widgets/state.rs
+++ b/crates/yakui-widgets/src/widgets/state.rs
@@ -22,6 +22,7 @@ impl<T: 'static> State<T> {
         }
     }
 
+    #[track_caller]
     pub fn show(self) -> Response<StateResponse<T>> {
         util::widget::<StateWidget<T>>(self)
     }

--- a/crates/yakui-widgets/src/widgets/text.rs
+++ b/crates/yakui-widgets/src/widgets/text.rs
@@ -68,6 +68,7 @@ impl Text {
         }
     }
 
+    #[track_caller]
     pub fn show(self) -> Response<TextResponse> {
         widget::<TextWidget>(self)
     }

--- a/crates/yakui-widgets/src/widgets/textbox.rs
+++ b/crates/yakui-widgets/src/widgets/textbox.rs
@@ -83,6 +83,7 @@ impl TextBox {
         }
     }
 
+    #[track_caller]
     pub fn show(self) -> Response<TextBoxResponse> {
         widget::<TextBoxWidget>(self)
     }

--- a/crates/yakui-widgets/src/widgets/unconstrained_box.rs
+++ b/crates/yakui-widgets/src/widgets/unconstrained_box.rs
@@ -24,6 +24,7 @@ impl UnconstrainedBox {
         }
     }
 
+    #[track_caller]
     pub fn show<F: FnOnce()>(self, children: F) -> Response<UnconstrainedBoxResponse> {
         widget_children::<UnconstrainedBoxWidget, F>(children, self)
     }

--- a/crates/yakui-widgets/src/widgets/window.rs
+++ b/crates/yakui-widgets/src/widgets/window.rs
@@ -27,6 +27,7 @@ impl Window {
         }
     }
 
+    #[track_caller]
     pub fn show<F: 'static + Fn()>(mut self, children: F) -> Response<WindowResponse> {
         self.children = Some(Box::new(children));
         widget::<WindowWidget>(self)

--- a/crates/yakui/examples/textbox_switcheroo.rs
+++ b/crates/yakui/examples/textbox_switcheroo.rs
@@ -1,0 +1,51 @@
+use yakui::{button, column, row, textbox, use_state};
+
+#[derive(Debug, Clone, Copy)]
+enum Page {
+    A,
+    B,
+}
+
+#[track_caller]
+fn row_st_d_ve_textbox(initial_text: &'static str) {
+    let text = use_state(|| initial_text.to_string());
+
+    row(|| {
+        row(|| {
+            row(|| {
+                let response = textbox(text.borrow().clone()).into_inner();
+
+                if let Some(new_text) = response.text {
+                    text.set(new_text);
+                }
+            });
+        });
+    });
+}
+
+pub fn run() {
+    let page = use_state(|| Page::A);
+
+    column(|| {
+        if button("page a").clicked {
+            page.set(Page::A);
+        }
+
+        if button("page b").clicked {
+            page.set(Page::B);
+        }
+
+        match page.get() {
+            Page::A => {
+                row_st_d_ve_textbox("a");
+            }
+            Page::B => {
+                row_st_d_ve_textbox("b");
+            }
+        };
+    });
+}
+
+fn main() {
+    bootstrap::start(run as fn());
+}


### PR DESCRIPTION
Sometimes we don't want to make a brand new widget struct just to wrap a few existing widgets into one, composed widget! Often, we'd have functions that make a few widgets, like a "helper" widget, but if you call this function conditionally, states will be reused incorrectly and disasters ensue.

Essentially, we'd move the callsite of the widgets *up* to wherever called said "helper" function, making all those widgets the function creates know who's the ACTUAL boss :P

