### PR TITLE
Allow users to manage their own painting (closes #171)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,6 @@ env_logger = "0.11.8"
 glam = "0.30.0"
 log = "0.4.17"
 pollster = "0.4.0"
-wgpu = "25.0.0"
+wgpu = "26.0.0"
 winit = "0.30.0"
 image = { version = "0.25.6", default-features = false }

--- a/crates/bootstrap/src/graphics.rs
+++ b/crates/bootstrap/src/graphics.rs
@@ -135,9 +135,9 @@ impl Graphics {
             let _render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                 label: Some("Render Pass"),
                 color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                    view: surface.color_attachment,
+                    view: surface.color_attachment.view,
                     depth_slice: None,
-                    resolve_target: surface.resolve_target,
+                    resolve_target: surface.color_attachment.resolve_target,
                     ops: wgpu::Operations {
                         load: wgpu::LoadOp::Clear(bg),
                         store: wgpu::StoreOp::Store,

--- a/crates/bootstrap/src/graphics.rs
+++ b/crates/bootstrap/src/graphics.rs
@@ -136,6 +136,7 @@ impl Graphics {
                 label: Some("Render Pass"),
                 color_attachments: &[Some(wgpu::RenderPassColorAttachment {
                     view: surface.color_attachment,
+                    depth_slice: None,
                     resolve_target: surface.resolve_target,
                     ops: wgpu::Operations {
                         load: wgpu::LoadOp::Clear(bg),

--- a/crates/bootstrap/src/multisampling.rs
+++ b/crates/bootstrap/src/multisampling.rs
@@ -34,8 +34,15 @@ impl Multisampling {
             return SurfaceInfo {
                 format,
                 sample_count,
-                color_attachment: view,
-                resolve_target: None,
+                color_attachment: wgpu::RenderPassColorAttachment {
+                    view,
+                    depth_slice: None,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Load,
+                        store: wgpu::StoreOp::Store,
+                    },
+                },
             };
         }
 
@@ -61,8 +68,15 @@ impl Multisampling {
         SurfaceInfo {
             format,
             sample_count,
-            color_attachment: ms_view,
-            resolve_target: Some(view),
+            color_attachment: wgpu::RenderPassColorAttachment {
+                view: ms_view,
+                depth_slice: None,
+                resolve_target: Some(view),
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Load,
+                    store: wgpu::StoreOp::Store,
+                },
+            },
         }
     }
 }

--- a/crates/yakui-app/src/lib.rs
+++ b/crates/yakui-app/src/lib.rs
@@ -156,9 +156,9 @@ impl Graphics {
             let _render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                 label: Some("Render Pass"),
                 color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                    view: surface.color_attachment,
+                    view: surface.color_attachment.view,
                     depth_slice: None,
-                    resolve_target: surface.resolve_target,
+                    resolve_target: surface.color_attachment.resolve_target,
                     ops: wgpu::Operations {
                         load: wgpu::LoadOp::Clear(bg),
                         store: wgpu::StoreOp::Store,

--- a/crates/yakui-app/src/lib.rs
+++ b/crates/yakui-app/src/lib.rs
@@ -157,6 +157,7 @@ impl Graphics {
                 label: Some("Render Pass"),
                 color_attachments: &[Some(wgpu::RenderPassColorAttachment {
                     view: surface.color_attachment,
+                    depth_slice: None,
                     resolve_target: surface.resolve_target,
                     ops: wgpu::Operations {
                         load: wgpu::LoadOp::Clear(bg),

--- a/crates/yakui-app/src/multisampling.rs
+++ b/crates/yakui-app/src/multisampling.rs
@@ -34,8 +34,15 @@ impl Multisampling {
             return SurfaceInfo {
                 format,
                 sample_count,
-                color_attachment: view,
-                resolve_target: None,
+                color_attachment: wgpu::RenderPassColorAttachment {
+                    view,
+                    depth_slice: None,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Load,
+                        store: wgpu::StoreOp::Store,
+                    },
+                },
             };
         }
 
@@ -61,8 +68,15 @@ impl Multisampling {
         SurfaceInfo {
             format,
             sample_count,
-            color_attachment: ms_view,
-            resolve_target: Some(view),
+            color_attachment: wgpu::RenderPassColorAttachment {
+                view: ms_view,
+                depth_slice: None,
+                resolve_target: Some(view),
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Load,
+                    store: wgpu::StoreOp::Store,
+                },
+            },
         }
     }
 }

--- a/crates/yakui-core/src/dom/mod.rs
+++ b/crates/yakui-core/src/dom/mod.rs
@@ -13,13 +13,13 @@ use std::mem::replace;
 use std::panic::Location;
 use std::rc::Rc;
 
-use anymap::AnyMap;
 use thunderdome::Arena;
 
 use crate::id::WidgetId;
 use crate::input::InputState;
 use crate::response::Response;
 use crate::widget::{ErasedWidget, Widget};
+use crate::Globals;
 
 use self::dummy::DummyWidget;
 use self::dynamic_scope::DynamicScope;
@@ -35,7 +35,7 @@ struct DomInner {
     stack: RefCell<Vec<WidgetId>>,
     removed_nodes: RefCell<Vec<WidgetId>>,
     root: WidgetId,
-    globals: RefCell<AnyMap>,
+    globals: RefCell<Globals>,
     pending_focus_request: RefCell<Option<WidgetId>>,
     dynamic_scope: DynamicScope,
 }
@@ -194,7 +194,7 @@ impl Dom {
         F: FnOnce() -> T,
     {
         let mut globals = self.inner.globals.borrow_mut();
-        globals.entry::<T>().or_insert_with(init).clone()
+        globals.get(init)
     }
 
     /// Convenience method for calling [`Dom::begin_widget`] immediately
@@ -292,7 +292,7 @@ impl DomInner {
         });
 
         Self {
-            globals: RefCell::new(AnyMap::new()),
+            globals: RefCell::new(Globals::new()),
             nodes: RefCell::new(nodes),
             removed_nodes: RefCell::new(Vec::new()),
             stack: RefCell::new(Vec::new()),

--- a/crates/yakui-core/src/globals.rs
+++ b/crates/yakui-core/src/globals.rs
@@ -1,0 +1,36 @@
+use anymap::AnyMap;
+
+/// Struct to hold generic global states.
+///
+/// See: [`crate::dom::Dom`], [`crate::paint::PaintDom`]
+#[derive(Debug)]
+pub struct Globals {
+    inner: AnyMap,
+}
+
+impl Globals {
+    /// Initalizes a new global-state holder.
+    pub fn new() -> Self {
+        Self {
+            inner: AnyMap::new(),
+        }
+    }
+
+    /// Get a piece of global state mutably or initialize it with the given function.
+    pub fn get_mut<T, F>(&mut self, init: F) -> &mut T
+    where
+        T: 'static,
+        F: FnOnce() -> T,
+    {
+        self.inner.entry::<T>().or_insert_with(init)
+    }
+
+    /// Get a piece of global state and clone it or initialize it with the given function.
+    pub fn get<T, F>(&mut self, init: F) -> T
+    where
+        T: 'static + Clone,
+        F: FnOnce() -> T,
+    {
+        self.inner.entry::<T>().or_insert_with(init).clone()
+    }
+}

--- a/crates/yakui-core/src/input/input_state.rs
+++ b/crates/yakui-core/src/input/input_state.rs
@@ -545,12 +545,7 @@ fn hit_test(_dom: &Dom, layout: &LayoutDom, coords: Vec2, output: &mut Vec<Widge
             continue;
         };
 
-        let mut rect = layout_node.rect;
-        let mut node = layout_node;
-        while let Some(parent) = node.clipped_by {
-            node = layout.get(parent).unwrap();
-            rect = rect.constrain(node.rect);
-        }
+        let rect = layout_node.clip.constrain(layout_node.rect);
 
         if rect.contains_point(coords) {
             output.push(id);

--- a/crates/yakui-core/src/layout/clipping.rs
+++ b/crates/yakui-core/src/layout/clipping.rs
@@ -1,0 +1,105 @@
+use glam::Vec2;
+
+use crate::geometry::Rect;
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ClipResolutionArgs {
+    pub parent_clip: Rect,
+    pub parent_rect: Rect,
+    pub layout_rect: Rect,
+    pub viewport: Rect,
+}
+
+/// Defines abstract sources of [`Rect`] for clipping resolution.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum AbstractClipRect {
+    /// Represents the parent widget's clipping rect.
+    ParentClip,
+    /// Represents the parent widget's layout rect.
+    ParentRect,
+    /// Represents the current widget's layout rect.
+    LayoutRect,
+    /// Represents the entire viewport rect.
+    Viewport,
+    /// The provided rect.
+    Value(Rect),
+}
+
+impl AbstractClipRect {
+    /// Turns the [`AbstractClipRect`] into a concrete [`Rect`].
+    pub(crate) fn to_rect(
+        self,
+        ClipResolutionArgs {
+            parent_clip,
+            parent_rect,
+            layout_rect,
+            viewport,
+        }: ClipResolutionArgs,
+    ) -> Rect {
+        match self {
+            AbstractClipRect::ParentClip => parent_clip,
+            AbstractClipRect::ParentRect => parent_rect,
+            AbstractClipRect::LayoutRect => layout_rect,
+            AbstractClipRect::Viewport => viewport,
+            AbstractClipRect::Value(rect) => rect,
+        }
+    }
+}
+
+/// Defines the clipping logic of clipping resolution.
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub enum ClipLogic {
+    /// No clipping logic is performed. The widget will simply reuse the parent's clipping rect.
+    #[default]
+    Pass,
+    /// The clipping rect will be the [`constrained`][Rect::constrain] result of the two rects.
+    Constrain(AbstractClipRect, AbstractClipRect),
+    /// If the widget is out of the [`parent`][ClipLogic::Contain::parent]'s bounds, try to push it back in first.
+    Contain {
+        /// The rect of the supposed widget in question.
+        it: AbstractClipRect,
+        /// The rect of the supposed widget's parent.
+        parent: AbstractClipRect,
+    },
+    /// The clipping rect will be overridden to be the provided rect.
+    Override(AbstractClipRect),
+}
+
+impl ClipLogic {
+    /// Resolves the offset for the *layout rect* with the provided [`ClipLogic`].
+    /// Should be calculated before doing clipping rect resolution, [`None`] means "just use the original layout rect".
+    pub(crate) fn resolve_offset(
+        self,
+        args @ ClipResolutionArgs { .. }: ClipResolutionArgs,
+    ) -> Option<Vec2> {
+        match self {
+            ClipLogic::Contain { it, parent } => {
+                let it = it.to_rect(args);
+                let parent = parent.to_rect(args);
+
+                let offset_min = Vec2::min(it.pos() - parent.pos(), Vec2::ZERO);
+                let offset_max = Vec2::min(-(it.max() - parent.max()), Vec2::ZERO);
+
+                Some(-offset_min + offset_max)
+            }
+            _ => None,
+        }
+    }
+
+    /// Resolves the *clipping rect* with the provided [`ClipLogic`].
+    pub(crate) fn resolve_clip(
+        self,
+        args @ ClipResolutionArgs { parent_clip, .. }: ClipResolutionArgs,
+    ) -> Rect {
+        match self {
+            ClipLogic::Pass => parent_clip,
+            ClipLogic::Constrain(a, b) | ClipLogic::Contain { it: a, parent: b } => {
+                let a = a.to_rect(args);
+                let b = b.to_rect(args);
+
+                a.constrain(b)
+            }
+            ClipLogic::Override(rect) => rect.to_rect(args),
+        }
+    }
+}

--- a/crates/yakui-core/src/layout/mod.rs
+++ b/crates/yakui-core/src/layout/mod.rs
@@ -78,19 +78,24 @@ impl LayoutDom {
         self.nodes.get_mut(id.index())
     }
 
-    /// Set the viewport of the DOM in unscaled units.
-    pub fn set_unscaled_viewport(&mut self, view: Rect) {
-        self.unscaled_viewport = view;
+    /// Get the viewport in unscaled units.
+    pub fn unscaled_viewport(&self) -> Rect {
+        self.unscaled_viewport
     }
 
-    /// Set the scale factor to use for layout.
-    pub fn set_scale_factor(&mut self, scale: f32) {
-        self.scale_factor = scale;
+    /// Set the viewport in unscaled units.
+    pub fn set_unscaled_viewport(&mut self, view: Rect) {
+        self.unscaled_viewport = view;
     }
 
     /// Get the currently active scale factor.
     pub fn scale_factor(&self) -> f32 {
         self.scale_factor
+    }
+
+    /// Set the currently active scale factor.
+    pub fn set_scale_factor(&mut self, scale: f32) {
+        self.scale_factor = scale;
     }
 
     /// Get the viewport in scaled units.
@@ -99,11 +104,6 @@ impl LayoutDom {
             self.unscaled_viewport.pos() / self.scale_factor,
             self.unscaled_viewport.size() / self.scale_factor,
         )
-    }
-
-    /// Get the viewport in unscaled units.
-    pub fn unscaled_viewport(&self) -> Rect {
-        self.unscaled_viewport
     }
 
     /// Tells how many nodes are currently in the `LayoutDom`.

--- a/crates/yakui-core/src/layout/mod.rs
+++ b/crates/yakui-core/src/layout/mod.rs
@@ -1,5 +1,9 @@
 //! Defines yakui's layout protocol and Layout DOM.
 
+mod clipping;
+
+pub use self::clipping::*;
+
 use std::collections::VecDeque;
 
 use glam::Vec2;
@@ -18,12 +22,13 @@ use crate::widget::LayoutContext;
 #[derive(Debug)]
 pub struct LayoutDom {
     nodes: Arena<LayoutDomNode>,
-    clip_stack: Vec<WidgetId>,
 
     unscaled_viewport: Rect,
     scale_factor: f32,
 
     pub(crate) interest_mouse: MouseInterest,
+
+    clip_logic_overrides: Arena<ClipLogic>,
 }
 
 /// A node in a [`LayoutDom`].
@@ -32,15 +37,12 @@ pub struct LayoutDomNode {
     /// The bounding rectangle of the node in logical pixels.
     pub rect: Rect,
 
-    /// This node will clip its descendants to its bounding rectangle.
-    pub clipping_enabled: bool,
+    /// The clipping rectangle of the node in logical pixels.
+    pub clip: Rect,
 
     /// This node is the beginning of a new layer, and all of its descendants
     /// should be hit tested and painted with higher priority.
     pub new_layer: bool,
-
-    /// This node is clipped to the region defined by the given node.
-    pub clipped_by: Option<WidgetId>,
 
     /// What events the widget reported interest in.
     pub event_interest: EventInterest,
@@ -51,12 +53,12 @@ impl LayoutDom {
     pub fn new() -> Self {
         Self {
             nodes: Arena::new(),
-            clip_stack: Vec::new(),
 
             unscaled_viewport: Rect::ONE,
             scale_factor: 1.0,
 
             interest_mouse: MouseInterest::new(),
+            clip_logic_overrides: Arena::new(),
         }
     }
 
@@ -119,13 +121,14 @@ impl LayoutDom {
         profiling::scope!("LayoutDom::calculate_all");
         log::debug!("LayoutDom::calculate_all()");
 
-        self.clip_stack.clear();
         self.interest_mouse.clear();
+        self.clip_logic_overrides.clear();
 
         let constraints = Constraints::tight(self.viewport().size());
 
         self.calculate(dom, input, paint, dom.root(), constraints);
         self.resolve_positions(dom);
+        self.resolve_clipping(dom);
     }
 
     /// Calculate the layout of a specific widget.
@@ -170,40 +173,37 @@ impl LayoutDom {
             self.interest_mouse.pop_layer();
         }
 
-        // If the widget called enable_clipping() during layout, it will be on
-        // top of the clip stack at this point.
-        let clipping_enabled = self.clip_stack.last() == Some(&id);
-
-        // If this node enabled clipping, the next node under that is the node
-        // that clips this one.
-        let clipped_by = if clipping_enabled {
-            self.clip_stack.iter().nth_back(2).copied()
-        } else {
-            self.clip_stack.last().copied()
-        };
-
         self.nodes.insert_at(
             id.index(),
             LayoutDomNode {
                 rect: Rect::from_pos_size(Vec2::ZERO, size),
-                clipping_enabled,
+                clip: Rect::ZERO,
                 new_layer,
-                clipped_by,
                 event_interest,
             },
         );
-
-        if clipping_enabled {
-            self.clip_stack.pop();
-        }
 
         dom.exit(id);
         size
     }
 
+    /// Sets the clipping logic for the currently active widget.
+    pub fn set_clip_logic(&mut self, dom: &Dom, logic: ClipLogic) {
+        self.clip_logic_overrides
+            .insert_at(dom.current().index(), logic);
+    }
+
     /// Enables clipping for the currently active widget.
     pub fn enable_clipping(&mut self, dom: &Dom) {
-        self.clip_stack.push(dom.current());
+        self.set_clip_logic(
+            dom,
+            ClipLogic::Constrain(AbstractClipRect::ParentClip, AbstractClipRect::LayoutRect),
+        );
+    }
+
+    /// Escapes clipping from the current clipping rect for the currently active widget.
+    pub fn escape_clipping(&mut self, dom: &Dom) {
+        self.set_clip_logic(dom, ClipLogic::Override(AbstractClipRect::Viewport));
     }
 
     /// Put this widget and its children into a new layer.
@@ -232,6 +232,58 @@ impl LayoutDom {
 
                 queue.extend(node.children.iter().map(|&id| (id, layout_node.rect.pos())));
             }
+        }
+    }
+
+    fn resolve_clipping(&mut self, dom: &Dom) {
+        let viewport = self.viewport();
+
+        let mut queue = VecDeque::new();
+
+        queue.push_back((dom.root(), viewport, viewport, Vec2::ZERO));
+
+        while let Some((id, parent_clip, parent_rect, mut offset)) = queue.pop_front() {
+            let Some(layout_node) = self.nodes.get_mut(id.index()) else {
+                continue;
+            };
+            let node = dom.get(id).unwrap();
+
+            let logic = self
+                .clip_logic_overrides
+                .get(id.index())
+                .copied()
+                .unwrap_or(ClipLogic::Pass);
+
+            let mut layout_rect = layout_node.rect;
+
+            // We need to do this before the clipping rect resolution.
+            // We might change the layout rect here, and that might change what the clipping should be.
+            if let Some(new_offset) = logic.resolve_offset(ClipResolutionArgs {
+                parent_clip,
+                parent_rect,
+                layout_rect,
+                viewport,
+            }) {
+                offset += new_offset;
+            }
+
+            layout_rect.set_pos(layout_rect.pos() + offset);
+
+            let clip_rect = logic.resolve_clip(ClipResolutionArgs {
+                parent_clip,
+                parent_rect,
+                layout_rect,
+                viewport,
+            });
+
+            layout_node.clip = clip_rect;
+            layout_node.rect = layout_rect;
+
+            queue.extend(
+                node.children
+                    .iter()
+                    .map(|&id| (id, clip_rect, layout_rect, offset)),
+            );
         }
     }
 }

--- a/crates/yakui-core/src/lib.rs
+++ b/crates/yakui-core/src/lib.rs
@@ -6,6 +6,7 @@
 #![deny(missing_docs)]
 #![doc = include_str!("../README.md")]
 
+mod globals;
 mod id;
 mod response;
 mod state;
@@ -21,6 +22,7 @@ pub mod navigation;
 pub mod paint;
 pub mod widget;
 
+pub use self::globals::*;
 pub use self::id::*;
 pub use self::response::*;
 pub use self::state::*;

--- a/crates/yakui-core/src/paint/layers.rs
+++ b/crates/yakui-core/src/paint/layers.rs
@@ -1,12 +1,14 @@
 use std::ops::Deref;
 
+use crate::geometry::Rect;
+
 use super::PaintCall;
 
 /// Contains all of the draw calls for a single layer of the UI.
 #[derive(Debug)]
 pub struct PaintLayer {
     /// The draw calls that can be used to paint this layer.
-    pub calls: Vec<PaintCall>,
+    pub calls: Vec<(Rect, PaintCall)>,
 }
 
 impl PaintLayer {

--- a/crates/yakui-core/src/paint/paint_dom.rs
+++ b/crates/yakui-core/src/paint/paint_dom.rs
@@ -36,7 +36,7 @@ pub struct PaintDom {
     limits: Option<PaintLimits>,
 
     layers: PaintLayers,
-    clip_stack: Vec<Rect>,
+    current_clip: Rect,
 }
 
 impl PaintDom {
@@ -51,7 +51,7 @@ impl PaintDom {
             limits: None,
 
             layers: PaintLayers::new(),
-            clip_stack: Vec::new(),
+            current_clip: Rect::ZERO,
         }
     }
 
@@ -68,7 +68,6 @@ impl PaintDom {
     /// Prepares the PaintDom to be updated for the frame.
     pub fn start(&mut self) {
         self.texture_edits.clear();
-        self.clip_stack.clear();
     }
 
     /// Returns the size of the surface that is being painted onto.
@@ -97,9 +96,11 @@ impl PaintDom {
         profiling::scope!("PaintDom::paint");
 
         let layout_node = layout.get(id).unwrap();
-        if layout_node.clipping_enabled {
-            self.push_clip(layout_node.rect);
-        }
+        self.current_clip = Rect::from_pos_size(
+            layout_node.clip.pos() * self.scale_factor,
+            layout_node.clip.size() * self.scale_factor,
+        );
+
         if layout_node.new_layer {
             self.layers.push();
         }
@@ -116,9 +117,6 @@ impl PaintDom {
 
         dom.exit(id);
 
-        if layout_node.clipping_enabled {
-            self.pop_clip();
-        }
         if layout_node.new_layer {
             self.layers.pop();
         }
@@ -198,12 +196,11 @@ impl PaintDom {
             .current_mut()
             .expect("an active layer is required to call add_mesh");
 
-        let current_clip = self.clip_stack.last().copied();
         let call = match layer.calls.last_mut() {
             Some(call)
                 if call.texture == texture_id
                     && call.pipeline == mesh.pipeline
-                    && call.clip == current_clip =>
+                    && call.clip == Some(self.current_clip) =>
             {
                 call
             }
@@ -211,7 +208,7 @@ impl PaintDom {
                 let mut call = PaintCall::new();
                 call.texture = texture_id;
                 call.pipeline = mesh.pipeline;
-                call.clip = current_clip;
+                call.clip = Some(self.current_clip);
 
                 layer.calls.push(call);
                 layer.calls.last_mut().unwrap()
@@ -243,28 +240,5 @@ impl PaintDom {
             vertex
         });
         call.vertices.extend(vertices);
-    }
-
-    /// Use the given region as the clipping rect for all following paint calls.
-    fn push_clip(&mut self, region: Rect) {
-        let mut unscaled = Rect::from_pos_size(
-            region.pos() * self.scale_factor,
-            region.size() * self.scale_factor,
-        );
-
-        if let Some(previous) = self.clip_stack.last() {
-            unscaled = unscaled.constrain(*previous);
-        }
-
-        self.clip_stack.push(unscaled);
-    }
-
-    /// Pop the most recent clip region, restoring the previous clipping rect.
-    fn pop_clip(&mut self) {
-        let top = self.clip_stack.pop();
-        debug_assert!(
-            top.is_some(),
-            "cannot call pop_clip without a corresponding push_clip call"
-        );
     }
 }

--- a/crates/yakui-core/src/paint/paint_dom.rs
+++ b/crates/yakui-core/src/paint/paint_dom.rs
@@ -110,6 +110,7 @@ impl PaintDom {
         let context = PaintContext {
             dom,
             layout,
+            clip: self.current_clip,
             paint: self,
         };
         let node = dom.get(id).unwrap();

--- a/crates/yakui-core/src/paint/paint_dom.rs
+++ b/crates/yakui-core/src/paint/paint_dom.rs
@@ -7,12 +7,14 @@ use crate::dom::Dom;
 use crate::geometry::Rect;
 use crate::id::{ManagedTextureId, WidgetId};
 use crate::layout::LayoutDom;
-use crate::paint::{PaintCall, Pipeline};
+use crate::paint::{PaintCall, Pipeline, YakuiPaintCall};
 use crate::widget::PaintContext;
+use crate::Globals;
 
 use super::layers::PaintLayers;
 use super::primitives::{PaintMesh, Vertex};
 use super::texture::{Texture, TextureChange};
+use super::UserPaintCallId;
 
 #[derive(Debug, Clone, Copy, Default)]
 /// Contains all information about the limits of the paint device.
@@ -25,18 +27,59 @@ pub struct PaintLimits {
     pub max_texture_size_3d: u32,
 }
 
+#[derive(Debug, Clone, Copy)]
+/// Contains misc info about the surface to be painted onto.
+pub struct PaintInfo {
+    surface_size: Vec2,
+    unscaled_viewport: Rect,
+    scale_factor: f32,
+}
+
+impl PaintInfo {
+    /// Transforms the vertex position from unit in logical pixels to a normalized position for rendering.
+    pub fn transform_vertex(&self, pos: Vec2, round_to_physical_pixel: bool) -> Vec2 {
+        transform_vertex(
+            pos,
+            self.scale_factor,
+            self.unscaled_viewport,
+            self.surface_size,
+            round_to_physical_pixel,
+        )
+    }
+}
+
+impl Default for PaintInfo {
+    fn default() -> Self {
+        Self {
+            surface_size: Vec2::ONE,
+            unscaled_viewport: Rect::ONE,
+            scale_factor: 1.0,
+        }
+    }
+}
+
 /// Contains all information about how to paint the current set of widgets.
 #[derive(Debug)]
 pub struct PaintDom {
     textures: Arena<Texture>,
     texture_edits: HashMap<ManagedTextureId, TextureChange>,
-    surface_size: Vec2,
-    unscaled_viewport: Rect,
-    scale_factor: f32,
+
     limits: Option<PaintLimits>,
 
-    layers: PaintLayers,
+    /// Contains misc info about the surface to be painted onto.
+    pub info: PaintInfo,
+
+    /// Stores the list of layers that should be used to draw the UI.
+    pub layers: PaintLayers,
+
+    /// Stores paint-persistent states.
+    /// For things like custom renderers, for example.
+    pub globals: Globals,
+
     current_clip: Rect,
+
+    #[cfg(debug_assertions)]
+    painted_already: bool,
 }
 
 impl PaintDom {
@@ -45,13 +88,17 @@ impl PaintDom {
         Self {
             textures: Arena::new(),
             texture_edits: HashMap::new(),
-            surface_size: Vec2::ONE,
-            unscaled_viewport: Rect::ONE,
-            scale_factor: 1.0,
+
             limits: None,
 
+            info: PaintInfo::default(),
             layers: PaintLayers::new(),
+            globals: Globals::new(),
+
             current_clip: Rect::ZERO,
+
+            #[cfg(debug_assertions)]
+            painted_already: false,
         }
     }
 
@@ -67,25 +114,42 @@ impl PaintDom {
 
     /// Prepares the PaintDom to be updated for the frame.
     pub fn start(&mut self) {
+        #[cfg(debug_assertions)]
+        {
+            self.painted_already = false;
+        }
+
         self.texture_edits.clear();
     }
 
-    /// Returns the size of the surface that is being painted onto.
+    /// Get the size of the surface that is being painted onto.
     pub fn surface_size(&self) -> Vec2 {
-        self.surface_size
+        self.info.surface_size
     }
 
-    /// Set the size of the surface that yakui is being rendered on.
+    /// Set the size of the surface that is being painted onto.
     pub(crate) fn set_surface_size(&mut self, size: Vec2) {
-        self.surface_size = size;
+        self.info.surface_size = size;
     }
 
+    /// Get the viewport in unscaled units.
+    pub fn unscaled_viewport(&self) -> Rect {
+        self.info.unscaled_viewport
+    }
+
+    /// Set the viewport in unscaled units.
     pub(crate) fn set_unscaled_viewport(&mut self, viewport: Rect) {
-        self.unscaled_viewport = viewport;
+        self.info.unscaled_viewport = viewport;
     }
 
+    /// Get the currently active scale factor.
+    pub fn scale_factor(&self) -> f32 {
+        self.info.scale_factor
+    }
+
+    /// Set the currently active scale factor.
     pub(crate) fn set_scale_factor(&mut self, scale_factor: f32) {
-        self.scale_factor = scale_factor;
+        self.info.scale_factor = scale_factor;
     }
 
     /// Paint a specific widget. This function is usually called as part of an
@@ -97,8 +161,8 @@ impl PaintDom {
 
         let layout_node = layout.get(id).unwrap();
         self.current_clip = Rect::from_pos_size(
-            layout_node.clip.pos() * self.scale_factor,
-            layout_node.clip.size() * self.scale_factor,
+            layout_node.clip.pos() * self.scale_factor(),
+            layout_node.clip.size() * self.scale_factor(),
         );
 
         if layout_node.new_layer {
@@ -130,6 +194,16 @@ impl PaintDom {
 
         self.layers.clear();
         self.paint(dom, layout, dom.root());
+
+        #[cfg(debug_assertions)]
+        {
+            debug_assert!(
+                !self.painted_already,
+                "PaintDom::paint_all() should only be called once per frame"
+            );
+
+            self.painted_already = true;
+        }
     }
 
     /// Add a texture to the Paint DOM, returning an ID that can be used to
@@ -177,11 +251,6 @@ impl PaintDom {
         self.texture_edits.iter().map(|(&id, &edit)| (id, edit))
     }
 
-    /// Returns a list of layers that should be used to draw the UI.
-    pub fn layers(&self) -> &PaintLayers {
-        &self.layers
-    }
-
     /// Add a mesh to be painted.
     pub fn add_mesh<V, I>(&mut self, mesh: PaintMesh<V, I>)
     where
@@ -198,21 +267,27 @@ impl PaintDom {
             .expect("an active layer is required to call add_mesh");
 
         let call = match layer.calls.last_mut() {
-            Some(call)
+            Some((clip, PaintCall::Internal(call)))
                 if call.texture == texture_id
                     && call.pipeline == mesh.pipeline
-                    && call.clip == Some(self.current_clip) =>
+                    && *clip == self.current_clip =>
             {
                 call
             }
             _ => {
-                let mut call = PaintCall::new();
+                let mut call = YakuiPaintCall::new();
                 call.texture = texture_id;
                 call.pipeline = mesh.pipeline;
-                call.clip = Some(self.current_clip);
 
-                layer.calls.push(call);
-                layer.calls.last_mut().unwrap()
+                layer
+                    .calls
+                    .push((self.current_clip, PaintCall::Internal(call)));
+
+                let Some((_, PaintCall::Internal(inserted))) = layer.calls.last_mut() else {
+                    panic!()
+                };
+
+                inserted
             }
         };
 
@@ -223,23 +298,51 @@ impl PaintDom {
         call.indices.extend(indices);
 
         let vertices = mesh.vertices.into_iter().map(|mut vertex| {
-            let mut pos = vertex.position * self.scale_factor;
-            pos += self.unscaled_viewport.pos();
-
             // Currently, we only round the vertices of geometry fed to the text
             // pipeline because rounding all geometry causes hairline cracks in
             // some geometry, like rounded rectangles.
             //
             // See: https://github.com/SecondHalfGames/yakui/issues/153
-            if mesh.pipeline == Pipeline::Text {
-                pos = pos.round();
-            }
+            let round = mesh.pipeline == Pipeline::Text;
 
-            pos /= self.surface_size;
+            vertex.position = self.info.transform_vertex(vertex.position, round);
 
-            vertex.position = pos;
             vertex
         });
         call.vertices.extend(vertices);
     }
+
+    /// Adds a user-managed paint call to be painted.
+    /// This expects the user to handle the paint call on their own, yakui just records the ID given to be checked against by the user later.
+    pub fn add_user_call(&mut self, call_id: UserPaintCallId) {
+        profiling::scope!("PaintDom::add_user_call");
+
+        let layer = self
+            .layers
+            .current_mut()
+            .expect("an active layer is required to call add_user_call");
+
+        layer
+            .calls
+            .push((self.current_clip, PaintCall::User(call_id)));
+    }
+}
+
+fn transform_vertex(
+    mut pos: Vec2,
+    scale_factor: f32,
+    unscaled_viewport: Rect,
+    surface_size: Vec2,
+    round_to_physical_pixel: bool,
+) -> Vec2 {
+    pos *= scale_factor;
+    pos += unscaled_viewport.pos();
+
+    if round_to_physical_pixel {
+        pos = pos.round();
+    }
+
+    pos /= surface_size;
+
+    pos
 }

--- a/crates/yakui-core/src/paint/primitives.rs
+++ b/crates/yakui-core/src/paint/primitives.rs
@@ -5,6 +5,7 @@ use crate::id::TextureId;
 
 #[allow(missing_docs)]
 pub struct PaintMesh<V, I> {
+    /// Vertex positions, the unit here is in logical pixels.
     pub vertices: V,
     pub indices: I,
     pub texture: Option<(TextureId, Rect)>,
@@ -28,27 +29,38 @@ where
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[allow(missing_docs)]
-pub struct PaintCall {
+pub struct YakuiPaintCall {
     pub vertices: Vec<Vertex>,
     pub indices: Vec<u16>,
     pub texture: Option<TextureId>,
     pub pipeline: Pipeline,
-    pub clip: Option<Rect>,
 }
 
-impl PaintCall {
-    /// Create a new empty `PaintCall`.
+impl YakuiPaintCall {
+    /// Create a new empty `YakuiPaintCall`.
     pub fn new() -> Self {
         Self {
             vertices: Vec::new(),
             indices: Vec::new(),
             texture: None,
             pipeline: Pipeline::Main,
-            clip: None,
         }
     }
+}
+
+/// A user-managed ID for an externally managed paint call
+pub type UserPaintCallId = u64;
+
+/// Represents a paint call that may be internal to yakui or handled by the user.
+#[derive(Debug)]
+pub enum PaintCall {
+    /// A paint call that is internal to yakui.
+    Internal(YakuiPaintCall),
+
+    /// A paint call that is managed by the user or renderer.
+    User(UserPaintCallId),
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/yakui-core/src/state.rs
+++ b/crates/yakui-core/src/state.rs
@@ -55,12 +55,12 @@ impl Yakui {
         self.paint.textures()
     }
 
-    /// Set the size of the surface the yakui is being rendered onto.
+    /// Set the size of the surface that is being rendered onto.
     pub fn set_surface_size(&mut self, size: Vec2) {
         self.paint.set_surface_size(size);
     }
 
-    /// Return the current size of the primary surface.
+    /// Get the size of the surface that is being painted onto.
     pub fn surface_size(&self) -> Vec2 {
         self.paint.surface_size()
     }
@@ -112,9 +112,9 @@ impl Yakui {
     /// Calculates the geometry needed to render the current state and gives
     /// access to the [`PaintDom`], which holds information about how to paint
     /// widgets.
-    pub fn paint(&mut self) -> &PaintDom {
+    pub fn paint(&mut self) -> &mut PaintDom {
         self.paint.paint_all(&self.dom, &self.layout);
-        &self.paint
+        &mut self.paint
     }
 
     /// Returns access to the state's DOM.

--- a/crates/yakui-core/src/widget.rs
+++ b/crates/yakui-core/src/widget.rs
@@ -9,7 +9,7 @@ use glam::Vec2;
 use crate::dom::Dom;
 use crate::event::EventResponse;
 use crate::event::{EventInterest, WidgetEvent};
-use crate::geometry::{Constraints, FlexFit};
+use crate::geometry::{Constraints, FlexFit, Rect};
 use crate::input::InputState;
 use crate::layout::LayoutDom;
 use crate::navigation::NavDirection;
@@ -48,6 +48,7 @@ pub struct PaintContext<'dom> {
     pub dom: &'dom Dom,
     pub layout: &'dom LayoutDom,
     pub paint: &'dom mut PaintDom,
+    pub clip: Rect,
 }
 
 impl PaintContext<'_> {

--- a/crates/yakui-to-image/src/graphics.rs
+++ b/crates/yakui-to-image/src/graphics.rs
@@ -95,8 +95,15 @@ impl Graphics {
         let surface = SurfaceInfo {
             format: self.format,
             sample_count: 1,
-            color_attachment: &view,
-            resolve_target: None,
+            color_attachment: wgpu::RenderPassColorAttachment {
+                view: &view,
+                depth_slice: None,
+                resolve_target: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Load,
+                    store: wgpu::StoreOp::Store,
+                },
+            },
         };
         let paint_yak = yak_renderer.paint(yak, &self.device, &self.queue, surface);
 

--- a/crates/yakui-to-image/src/graphics.rs
+++ b/crates/yakui-to-image/src/graphics.rs
@@ -79,6 +79,7 @@ impl Graphics {
                 label: Some("Clear"),
                 color_attachments: &[Some(wgpu::RenderPassColorAttachment {
                     view: &view,
+                    depth_slice: None,
                     resolve_target: None,
                     ops: wgpu::Operations {
                         load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),

--- a/crates/yakui-vulkan/examples/custom_vulkan_renderer.rs
+++ b/crates/yakui-vulkan/examples/custom_vulkan_renderer.rs
@@ -1,0 +1,1071 @@
+use std::time::Instant;
+
+use ash::vk;
+use bytemuck::bytes_of;
+use thunderdome::{Arena, Index};
+use yakui::paint::{PaintCall, UserPaintCallId};
+use yakui::util::widget;
+use yakui::widget::Widget;
+use yakui::{Color, Rect, UVec2, Vec2};
+use yakui_vulkan::*;
+
+use winit::{
+    event::{ElementState, Event, KeyEvent, WindowEvent},
+    event_loop::ControlFlow,
+    keyboard::{KeyCode, PhysicalKey},
+};
+
+#[derive(Debug)]
+struct MyCustomRenderer {
+    objects: Arena<MyCustomRenderedObject>,
+    initial_time: Instant,
+}
+
+impl MyCustomRenderer {
+    pub fn add(&mut self, object: MyCustomRenderedObject) -> UserPaintCallId {
+        self.objects.insert(object).to_bits()
+    }
+
+    pub fn clear(&mut self) {
+        self.objects.clear();
+    }
+
+    pub fn new() -> Self {
+        Self {
+            objects: Arena::new(),
+            initial_time: Instant::now(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct MyCustomRenderedObject {
+    color: Color,
+}
+
+impl MyCustomRenderedObject {
+    pub fn show(self) -> yakui::Response<()> {
+        widget::<MyCustomRenderedWidget>(self)
+    }
+}
+
+#[derive(Debug)]
+struct MyCustomRenderedWidget {
+    props: MyCustomRenderedObject,
+}
+
+impl Widget for MyCustomRenderedWidget {
+    type Props<'a> = MyCustomRenderedObject;
+
+    type Response = ();
+
+    fn new() -> Self {
+        Self {
+            props: MyCustomRenderedObject {
+                color: Color::CLEAR,
+            },
+        }
+    }
+
+    fn update(&mut self, props: Self::Props<'_>) -> Self::Response {
+        self.props = props
+    }
+
+    fn layout(
+        &self,
+        ctx: yakui::widget::LayoutContext<'_>,
+        _constraints: yakui::Constraints,
+    ) -> yakui::Vec2 {
+        ctx.layout.enable_clipping(ctx.dom);
+
+        yakui::Vec2::new(80., 80.)
+    }
+
+    fn paint(&self, ctx: yakui::widget::PaintContext<'_>) {
+        let id = ctx
+            .paint
+            .globals
+            .get_mut(MyCustomRenderer::new)
+            .add(self.props);
+
+        ctx.paint.add_user_call(id);
+    }
+}
+
+unsafe fn my_custom_paint(
+    yakui_vulkan: &mut YakuiVulkan,
+    paint: &mut yakui_core::paint::PaintDom,
+    vulkan_context: &VulkanContext,
+    cmd: vk::CommandBuffer,
+    resolution: vk::Extent2D,
+) {
+    // --- yakui ---
+    // If there's nothing to paint, well... don't paint!
+    let layers = &paint.layers;
+    if layers.iter().all(|layer| layer.calls.is_empty()) {
+        return;
+    }
+
+    // If the surface has a size of zero, well... don't paint either!
+    if paint.surface_size().x == 0.0 || paint.surface_size().y == 0.0 {
+        return;
+    }
+
+    let mut vertices: Vec<Vertex> = Default::default();
+    let mut indices: Vec<u32> = Default::default();
+    let mut draw_calls: Vec<(Rect, DrawCall)> = Default::default();
+    // --- yakui ---
+
+    let renderer = paint.globals.get_mut(MyCustomRenderer::new);
+
+    let mut custom_draws = Arena::new();
+    let elapsed = Instant::now()
+        .duration_since(renderer.initial_time)
+        .as_secs_f32();
+
+    for (clip, call) in layers.iter().flat_map(|layer| &layer.calls) {
+        match call {
+            PaintCall::Internal(call) => {
+                draw_calls.push(yakui_vulkan.build_draw_call(
+                    &mut vertices,
+                    &mut indices,
+                    *clip,
+                    call,
+                ));
+            }
+            PaintCall::User(id) => {
+                let min = clip.pos();
+                let max = clip.max();
+
+                let x1y1 = min;
+                let x1y2 = Vec2::new(min.x, max.y);
+                let x2y1 = Vec2::new(max.x, min.y);
+                let x2y2 = max;
+
+                let index = Index::from_bits(*id).unwrap();
+                let object = renderer.objects.get(index).unwrap();
+                let mut color = object.color.to_linear();
+
+                color.x = (color.x + elapsed).sin().abs();
+                color.y = (color.y + elapsed).cos().abs();
+
+                let my_indices = [0, 1, 2, 1, 3, 2];
+
+                let base = vertices.len() as u32;
+                let index_offset = indices.len() as u32;
+                let index_count = my_indices.len() as u32;
+
+                for i in my_indices {
+                    indices.push(i as u32 + base);
+                }
+
+                for pos in [x1y1, x1y2, x2y1, x2y2] {
+                    vertices.push(Vertex {
+                        position: paint.info.transform_vertex(pos, false),
+                        texcoord: Vec2::default(),
+                        color,
+                    });
+                }
+
+                draw_calls.push((*clip, DrawCall::User(*id)));
+                custom_draws.insert_at(index, (index_offset, index_count));
+            }
+        }
+    }
+
+    renderer.clear();
+
+    // --- yakui ---
+    unsafe {
+        yakui_vulkan.index_buffer.write(vulkan_context, 0, &indices);
+        yakui_vulkan
+            .vertex_buffer
+            .write(vulkan_context, 0, &vertices);
+    }
+
+    let device = vulkan_context.device;
+    let surface_size = UVec2::new(resolution.width, resolution.height);
+    // --- yakui ---
+
+    unsafe {
+        // --- yakui ---
+        device.cmd_bind_pipeline(
+            cmd,
+            vk::PipelineBindPoint::GRAPHICS,
+            yakui_vulkan.graphics_pipeline,
+        );
+        let default_scissor = [resolution.into()];
+        device.cmd_set_scissor(cmd, 0, &default_scissor);
+
+        device.cmd_bind_vertex_buffers(cmd, 0, &[yakui_vulkan.vertex_buffer.handle], &[0]);
+        device.cmd_bind_index_buffer(
+            cmd,
+            yakui_vulkan.index_buffer.handle,
+            0,
+            vk::IndexType::UINT32,
+        );
+        device.cmd_bind_descriptor_sets(
+            cmd,
+            vk::PipelineBindPoint::GRAPHICS,
+            yakui_vulkan.pipeline_layout,
+            0,
+            std::slice::from_ref(&yakui_vulkan.descriptors.set),
+            &[],
+        );
+
+        let mut last_clip = None;
+
+        for (clip, draw_call) in draw_calls {
+            if Some(clip) != last_clip {
+                last_clip = Some(clip);
+
+                // TODO - do this when processing draw calls
+                let pos = clip.pos().as_uvec2();
+                let size = clip.size().as_uvec2();
+
+                let max = (pos + size).min(surface_size);
+                let size = UVec2::new(max.x.saturating_sub(pos.x), max.y.saturating_sub(pos.y));
+
+                // If the scissor rect isn't valid, we can skip this
+                // entire draw call.
+                if pos.x > surface_size.x || pos.y > surface_size.y || size.x == 0 || size.y == 0 {
+                    continue;
+                }
+
+                let scissors = [vk::Rect2D {
+                    offset: vk::Offset2D {
+                        x: pos.x as _,
+                        y: pos.y as _,
+                    },
+                    extent: vk::Extent2D {
+                        width: size.x,
+                        height: size.y,
+                    },
+                }];
+                // If there's a clip, update the scissor
+                device.cmd_set_scissor(cmd, 0, &scissors);
+            }
+            // --- yakui ---
+
+            match draw_call {
+                DrawCall::Yakui(draw_call) => {
+                    yakui_vulkan.draw_yakui(vulkan_context, cmd, draw_call);
+                }
+                DrawCall::User(id) => {
+                    device.cmd_push_constants(
+                        cmd,
+                        yakui_vulkan.pipeline_layout,
+                        vk::ShaderStageFlags::FRAGMENT,
+                        0,
+                        bytes_of(&PushConstant::new(NO_TEXTURE_ID, Workflow::Main)),
+                    );
+
+                    let (index_offset, index_count) =
+                        custom_draws.remove(Index::from_bits(id).unwrap()).unwrap();
+
+                    device.cmd_draw_indexed(cmd, index_count, 1, index_offset, 0, 1);
+                }
+            }
+        }
+    }
+}
+
+/// Simple test to make sure Vulkan backend renders properly with a custom renderer.
+fn main() {
+    use winit::dpi::PhysicalSize;
+
+    let (width, height) = (500, 500);
+    let (event_loop, window) = init_winit(width, height);
+    let mut vulkan_test = VulkanTest::new(width, height, &window);
+
+    let mut yak = yakui::Yakui::new();
+    yak.set_surface_size([width as f32, height as f32].into());
+    yak.set_unscaled_viewport(Rect::from_pos_size(
+        Default::default(),
+        [width as f32, height as f32].into(),
+    ));
+
+    let mut yakui_vulkan = {
+        let vulkan_context = VulkanContext::new(
+            &vulkan_test.device,
+            vulkan_test.present_queue,
+            vulkan_test.device_memory_properties,
+            vulkan_test.device_properties,
+        );
+        let options = yakui_vulkan::Options {
+            render_pass: vulkan_test.render_pass,
+            ..Default::default()
+        };
+        let mut yakui_vulkan = YakuiVulkan::new(&vulkan_context, options);
+        yakui_vulkan.set_paint_limits(&vulkan_context, &mut yak);
+        // Prepare for one frame in flight
+        yakui_vulkan.transfers_submitted();
+        yakui_vulkan
+    };
+
+    let mut winit_initializing = true;
+
+    event_loop.set_control_flow(ControlFlow::Poll);
+    #[allow(deprecated)] // winit!! :shakes-fist:
+    let _ = event_loop.run(|event, event_loop| match event {
+        Event::WindowEvent {
+            event:
+                WindowEvent::CloseRequested
+                | WindowEvent::KeyboardInput {
+                    event:
+                        KeyEvent {
+                            state: ElementState::Pressed,
+                            physical_key: PhysicalKey::Code(KeyCode::Escape),
+                            ..
+                        },
+                    ..
+                },
+            ..
+        } => event_loop.exit(),
+
+        Event::NewEvents(cause) => {
+            winit_initializing = cause == winit::event::StartCause::Init;
+        }
+
+        Event::AboutToWait => {
+            let vulkan_context = VulkanContext::new(
+                &vulkan_test.device,
+                vulkan_test.present_queue,
+                vulkan_test.device_memory_properties,
+                vulkan_test.device_properties,
+            );
+
+            yak.start();
+            gui();
+            yak.finish();
+
+            let paint = yak.paint();
+
+            let index = vulkan_test.cmd_begin();
+            unsafe {
+                yakui_vulkan.transfers_finished(&vulkan_context);
+                yakui_vulkan.transfer(paint, &vulkan_context, vulkan_test.draw_command_buffer);
+            }
+            vulkan_test.render_begin(index);
+            unsafe {
+                my_custom_paint(
+                    &mut yakui_vulkan,
+                    paint,
+                    &vulkan_context,
+                    vulkan_test.draw_command_buffer,
+                    vulkan_test.swapchain_info.surface_resolution,
+                );
+            }
+
+            vulkan_test.render_end(index);
+            yakui_vulkan.transfers_submitted();
+        }
+        Event::WindowEvent {
+            event: WindowEvent::Resized(size),
+            ..
+        } => {
+            if winit_initializing {
+                println!("Ignoring resize during init!");
+            } else {
+                let PhysicalSize { width, height } = size;
+                vulkan_test.resized(width, height);
+                yak.set_surface_size([width as f32, height as f32].into());
+                yak.set_unscaled_viewport(Rect::from_pos_size(
+                    Default::default(),
+                    [width as f32, height as f32].into(),
+                ));
+            }
+        }
+        Event::WindowEvent {
+            event: WindowEvent::ScaleFactorChanged { scale_factor, .. },
+            ..
+        } => yak.set_scale_factor(scale_factor as _),
+        _ => (),
+    });
+
+    unsafe {
+        yakui_vulkan.cleanup(&vulkan_test.device);
+    }
+}
+
+fn gui() {
+    use yakui::{column, label, row, widgets::Text, Color};
+    column(|| {
+        row(|| {
+            label("Hello, world!");
+
+            let mut text = Text::new(48.0, "colored text!");
+            text.style.color = Color::RED;
+            text.show();
+        });
+
+        row(|| {
+            MyCustomRenderedObject { color: Color::RED }.show();
+            MyCustomRenderedObject {
+                color: Color::GREEN,
+            }
+            .show();
+            MyCustomRenderedObject { color: Color::BLUE }.show();
+            MyCustomRenderedObject {
+                color: Color::YELLOW,
+            }
+            .show();
+            MyCustomRenderedObject {
+                color: Color::WHITE,
+            }
+            .show();
+            MyCustomRenderedObject {
+                color: Color::FUCHSIA,
+            }
+            .show();
+        });
+    });
+}
+
+struct VulkanTest {
+    _entry: ash::Entry,
+    device: ash::Device,
+    physical_device: vk::PhysicalDevice,
+    instance: ash::Instance,
+    surface_loader: ash::khr::surface::Instance,
+    device_memory_properties: vk::PhysicalDeviceMemoryProperties,
+    device_properties: vk::PhysicalDeviceProperties,
+
+    present_queue: vk::Queue,
+
+    surface: vk::SurfaceKHR,
+    swapchain_info: SwapchainInfo,
+
+    swapchain: vk::SwapchainKHR,
+    present_image_views: Vec<vk::ImageView>,
+
+    render_pass: vk::RenderPass,
+    framebuffers: Vec<vk::Framebuffer>,
+
+    command_pool: vk::CommandPool,
+    draw_command_buffer: vk::CommandBuffer,
+
+    present_complete_semaphore: vk::Semaphore,
+    rendering_complete_semaphore: vk::Semaphore,
+
+    draw_commands_reuse_fence: vk::Fence,
+    setup_commands_reuse_fence: vk::Fence,
+}
+
+impl VulkanTest {
+    /// Bring up all the Vulkan pomp and ceremony required to render things.
+    /// Vulkan Broadly lifted from: https://github.com/ash-rs/ash/blob/0.37.2/examples/src/lib.rs
+    pub fn new(window_width: u32, window_height: u32, window: &winit::window::Window) -> Self {
+        use raw_window_handle::{HasDisplayHandle, HasWindowHandle};
+
+        let entry = unsafe { ash::Entry::load().expect("failed to load Vulkan") };
+        let app_name = c"Yakui Vulkan Test";
+
+        let appinfo = vk::ApplicationInfo::default()
+            .application_name(app_name)
+            .application_version(0)
+            .engine_name(app_name)
+            .engine_version(0)
+            .api_version(vk::make_api_version(0, 1, 3, 0));
+
+        #[allow(unused_mut)]
+        let mut extension_names =
+            ash_window::enumerate_required_extensions(window.display_handle().unwrap().as_raw())
+                .unwrap()
+                .to_vec();
+
+        #[cfg(target_os = "macos")]
+        extension_names.push(ash::khr::portability_enumeration::NAME.as_ptr());
+
+        let create_flags = if cfg!(target_os = "macos") {
+            vk::InstanceCreateFlags::ENUMERATE_PORTABILITY_KHR
+        } else {
+            vk::InstanceCreateFlags::default()
+        };
+
+        let create_info = vk::InstanceCreateInfo::default()
+            .flags(create_flags)
+            .application_info(&appinfo)
+            .enabled_extension_names(&extension_names);
+
+        let instance = unsafe {
+            entry
+                .create_instance(&create_info, None)
+                .expect("Instance creation error")
+        };
+
+        let surface = unsafe {
+            ash_window::create_surface(
+                &entry,
+                &instance,
+                window.display_handle().unwrap().as_raw(),
+                window.window_handle().unwrap().as_raw(),
+                None,
+            )
+            .unwrap()
+        };
+
+        let pdevices = unsafe {
+            instance
+                .enumerate_physical_devices()
+                .expect("Physical device error")
+        };
+        let surface_loader = ash::khr::surface::Instance::new(&entry, &instance);
+        let (physical_device, queue_family_index) = unsafe {
+            pdevices
+                .iter()
+                .find_map(|pdevice| {
+                    instance
+                        .get_physical_device_queue_family_properties(*pdevice)
+                        .iter()
+                        .enumerate()
+                        .find_map(|(index, info)| {
+                            let supports_graphic_and_surface =
+                                info.queue_flags.contains(vk::QueueFlags::GRAPHICS)
+                                    && surface_loader
+                                        .get_physical_device_surface_support(
+                                            *pdevice,
+                                            index as u32,
+                                            surface,
+                                        )
+                                        .unwrap();
+                            if supports_graphic_and_surface {
+                                Some((*pdevice, index))
+                            } else {
+                                None
+                            }
+                        })
+                })
+                .expect("Couldn't find suitable device.")
+        };
+        let queue_family_index = queue_family_index as u32;
+
+        #[allow(unused_mut)]
+        let mut device_exts = vec![ash::khr::swapchain::NAME.as_ptr()];
+
+        #[cfg(target_os = "macos")]
+        device_exts.push(ash::khr::portability_subset::NAME.as_ptr());
+
+        let priorities = [1.0];
+
+        let queue_info = vk::DeviceQueueCreateInfo::default()
+            .queue_family_index(queue_family_index)
+            .queue_priorities(&priorities);
+
+        let mut descriptor_indexing_features =
+            vk::PhysicalDeviceDescriptorIndexingFeatures::default()
+                .descriptor_binding_partially_bound(true)
+                .descriptor_binding_sampled_image_update_after_bind(true);
+
+        let device_create_info = vk::DeviceCreateInfo::default()
+            .queue_create_infos(std::slice::from_ref(&queue_info))
+            .enabled_extension_names(&device_exts)
+            .push_next(&mut descriptor_indexing_features);
+
+        let device = unsafe {
+            instance
+                .create_device(physical_device, &device_create_info, None)
+                .unwrap()
+        };
+
+        let present_queue = unsafe { device.get_device_queue(queue_family_index, 0) };
+        let surface_format = unsafe {
+            surface_loader
+                .get_physical_device_surface_formats(physical_device, surface)
+                .unwrap()[0]
+        };
+
+        let surface_capabilities = unsafe {
+            surface_loader
+                .get_physical_device_surface_capabilities(physical_device, surface)
+                .unwrap()
+        };
+        let mut desired_image_count = surface_capabilities.min_image_count + 1;
+        if surface_capabilities.max_image_count > 0
+            && desired_image_count > surface_capabilities.max_image_count
+        {
+            desired_image_count = surface_capabilities.max_image_count;
+        }
+        let surface_resolution = match surface_capabilities.current_extent.width {
+            std::u32::MAX => vk::Extent2D {
+                width: window_width,
+                height: window_height,
+            },
+            _ => surface_capabilities.current_extent,
+        };
+
+        let present_modes = unsafe {
+            surface_loader
+                .get_physical_device_surface_present_modes(physical_device, surface)
+                .unwrap()
+        };
+        let present_mode = present_modes
+            .iter()
+            .cloned()
+            .find(|&mode| mode == vk::PresentModeKHR::MAILBOX)
+            .unwrap_or(vk::PresentModeKHR::FIFO);
+        let swapchain_loader = ash::khr::swapchain::Device::new(&instance, &device);
+
+        let swapchain_info = SwapchainInfo::new(
+            swapchain_loader,
+            surface_format,
+            surface_resolution,
+            present_mode,
+            surface,
+            desired_image_count,
+        );
+
+        let (swapchain, present_image_views) = create_swapchain(&device, None, &swapchain_info);
+
+        let renderpass_attachments = [vk::AttachmentDescription {
+            format: swapchain_info.surface_format.format,
+            samples: vk::SampleCountFlags::TYPE_1,
+            load_op: vk::AttachmentLoadOp::CLEAR,
+            store_op: vk::AttachmentStoreOp::STORE,
+            final_layout: vk::ImageLayout::PRESENT_SRC_KHR,
+            ..Default::default()
+        }];
+        let color_attachment_refs = [vk::AttachmentReference {
+            attachment: 0,
+            layout: vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL,
+        }];
+        let dependencies = [vk::SubpassDependency {
+            src_subpass: vk::SUBPASS_EXTERNAL,
+            src_stage_mask: vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT,
+            dst_access_mask: vk::AccessFlags::COLOR_ATTACHMENT_READ
+                | vk::AccessFlags::COLOR_ATTACHMENT_WRITE,
+            dst_stage_mask: vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT,
+            ..Default::default()
+        }];
+
+        let subpass = vk::SubpassDescription::default()
+            .color_attachments(&color_attachment_refs)
+            .pipeline_bind_point(vk::PipelineBindPoint::GRAPHICS);
+
+        let renderpass_create_info = vk::RenderPassCreateInfo::default()
+            .attachments(&renderpass_attachments)
+            .subpasses(std::slice::from_ref(&subpass))
+            .dependencies(&dependencies);
+
+        let render_pass = unsafe {
+            device
+                .create_render_pass(&renderpass_create_info, None)
+                .unwrap()
+        };
+
+        let framebuffers = create_framebuffers(
+            &present_image_views,
+            surface_resolution,
+            render_pass,
+            &device,
+        );
+
+        let pool_create_info = vk::CommandPoolCreateInfo::default()
+            .flags(vk::CommandPoolCreateFlags::RESET_COMMAND_BUFFER)
+            .queue_family_index(queue_family_index);
+
+        let pool = unsafe { device.create_command_pool(&pool_create_info, None).unwrap() };
+
+        let command_buffer_allocate_info = vk::CommandBufferAllocateInfo::default()
+            .command_buffer_count(1)
+            .command_pool(pool)
+            .level(vk::CommandBufferLevel::PRIMARY);
+
+        let command_buffers = unsafe {
+            device
+                .allocate_command_buffers(&command_buffer_allocate_info)
+                .unwrap()
+        };
+        let draw_command_buffer = command_buffers[0];
+
+        let fence_create_info =
+            vk::FenceCreateInfo::default().flags(vk::FenceCreateFlags::SIGNALED);
+
+        let draw_commands_reuse_fence = unsafe {
+            device
+                .create_fence(&fence_create_info, None)
+                .expect("Create fence failed.")
+        };
+        let setup_commands_reuse_fence = unsafe {
+            device
+                .create_fence(&fence_create_info, None)
+                .expect("Create fence failed.")
+        };
+
+        let semaphore_create_info = vk::SemaphoreCreateInfo::default();
+
+        let present_complete_semaphore = unsafe {
+            device
+                .create_semaphore(&semaphore_create_info, None)
+                .unwrap()
+        };
+        let rendering_complete_semaphore = unsafe {
+            device
+                .create_semaphore(&semaphore_create_info, None)
+                .unwrap()
+        };
+
+        let device_memory_properties =
+            unsafe { instance.get_physical_device_memory_properties(physical_device) };
+
+        let device_properties = unsafe { instance.get_physical_device_properties(physical_device) };
+
+        Self {
+            device,
+            physical_device,
+            present_queue,
+            _entry: entry,
+            instance,
+            surface_loader,
+            swapchain_info,
+            device_memory_properties,
+            device_properties,
+            surface,
+            swapchain,
+            present_image_views,
+            render_pass,
+            framebuffers,
+            command_pool: pool,
+            draw_command_buffer,
+            present_complete_semaphore,
+            rendering_complete_semaphore,
+            draw_commands_reuse_fence,
+            setup_commands_reuse_fence,
+        }
+    }
+
+    pub fn resized(&mut self, window_width: u32, window_height: u32) {
+        unsafe {
+            self.device.device_wait_idle().unwrap();
+            let surface_capabilities = self
+                .surface_loader
+                .get_physical_device_surface_capabilities(self.physical_device, self.surface)
+                .unwrap();
+            let surface_resolution = match surface_capabilities.current_extent.width {
+                std::u32::MAX => vk::Extent2D {
+                    width: window_width,
+                    height: window_height,
+                },
+                _ => surface_capabilities.current_extent,
+            };
+            self.swapchain_info.surface_resolution = surface_resolution;
+            let (new_swapchain, new_present_image_views) =
+                create_swapchain(&self.device, Some(self.swapchain), &self.swapchain_info);
+            let framebuffers = create_framebuffers(
+                &new_present_image_views,
+                self.swapchain_info.surface_resolution,
+                self.render_pass,
+                &self.device,
+            );
+
+            self.destroy_swapchain(self.swapchain);
+            self.present_image_views = new_present_image_views;
+            self.swapchain = new_swapchain;
+            self.framebuffers = framebuffers;
+        }
+    }
+
+    unsafe fn destroy_swapchain(&self, swapchain: vk::SwapchainKHR) {
+        let device = &self.device;
+        for &fb in &self.framebuffers {
+            device.destroy_framebuffer(fb, None);
+        }
+        for image_view in &self.present_image_views {
+            device.destroy_image_view(*image_view, None);
+        }
+        self.swapchain_info
+            .swapchain_loader
+            .destroy_swapchain(swapchain, None);
+    }
+
+    pub fn cmd_begin(&self) -> u32 {
+        let (present_index, _) = unsafe {
+            self.swapchain_info
+                .swapchain_loader
+                .acquire_next_image(
+                    self.swapchain,
+                    u64::MAX,
+                    self.present_complete_semaphore,
+                    vk::Fence::null(),
+                )
+                .unwrap()
+        };
+
+        let device = &self.device;
+        unsafe {
+            device
+                .wait_for_fences(
+                    std::slice::from_ref(&self.draw_commands_reuse_fence),
+                    true,
+                    u64::MAX,
+                )
+                .unwrap();
+            device
+                .reset_fences(std::slice::from_ref(&self.draw_commands_reuse_fence))
+                .unwrap();
+            device
+                .reset_command_buffer(
+                    self.draw_command_buffer,
+                    vk::CommandBufferResetFlags::RELEASE_RESOURCES,
+                )
+                .unwrap();
+            device
+                .begin_command_buffer(
+                    self.draw_command_buffer,
+                    &vk::CommandBufferBeginInfo::default()
+                        .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT),
+                )
+                .unwrap();
+        }
+        present_index
+    }
+
+    pub fn render_begin(&self, present_index: u32) -> u32 {
+        let device = &self.device;
+        unsafe {
+            let clear_values = [
+                vk::ClearValue {
+                    color: vk::ClearColorValue {
+                        float32: [0.0, 0.0, 0.0, 0.0],
+                    },
+                },
+                vk::ClearValue {
+                    depth_stencil: vk::ClearDepthStencilValue {
+                        depth: 1.0,
+                        stencil: 0,
+                    },
+                },
+            ];
+            let viewports = [vk::Viewport {
+                x: 0.0,
+                y: 0.0,
+                width: self.swapchain_info.surface_resolution.width as f32,
+                height: self.swapchain_info.surface_resolution.height as f32,
+                min_depth: 0.0,
+                max_depth: 1.0,
+            }];
+
+            let render_pass_begin_info = vk::RenderPassBeginInfo::default()
+                .render_pass(self.render_pass)
+                .framebuffer(self.framebuffers[present_index as usize])
+                .render_area(self.swapchain_info.surface_resolution.into())
+                .clear_values(&clear_values);
+
+            device.cmd_begin_render_pass(
+                self.draw_command_buffer,
+                &render_pass_begin_info,
+                vk::SubpassContents::INLINE,
+            );
+            device.cmd_set_viewport(self.draw_command_buffer, 0, &viewports);
+            device.cmd_set_scissor(
+                self.draw_command_buffer,
+                0,
+                &[self.swapchain_info.surface_resolution.into()],
+            );
+        }
+        present_index
+    }
+
+    pub fn render_end(&self, present_index: u32) {
+        let device = &self.device;
+        unsafe {
+            device.cmd_end_render_pass(self.draw_command_buffer);
+            device.end_command_buffer(self.draw_command_buffer).unwrap();
+            let swapchains = [self.swapchain];
+            let image_indices = [present_index];
+            let submit_info = vk::SubmitInfo::default()
+                .wait_semaphores(std::slice::from_ref(&self.present_complete_semaphore))
+                .wait_dst_stage_mask(&[vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT])
+                .command_buffers(std::slice::from_ref(&self.draw_command_buffer))
+                .signal_semaphores(std::slice::from_ref(&self.rendering_complete_semaphore));
+
+            device
+                .queue_submit(
+                    self.present_queue,
+                    std::slice::from_ref(&submit_info),
+                    self.draw_commands_reuse_fence,
+                )
+                .unwrap();
+
+            match self.swapchain_info.swapchain_loader.queue_present(
+                self.present_queue,
+                &vk::PresentInfoKHR::default()
+                    .image_indices(&image_indices)
+                    .wait_semaphores(std::slice::from_ref(&self.rendering_complete_semaphore))
+                    .swapchains(&swapchains),
+            ) {
+                Ok(true) | Err(vk::Result::ERROR_OUT_OF_DATE_KHR) => {
+                    // this usually indicates the window has been resized
+                }
+                Err(e) => panic!("Error presenting: {e:?}"),
+                _ => {}
+            }
+        };
+    }
+}
+
+fn init_winit(
+    window_width: u32,
+    window_height: u32,
+) -> (winit::event_loop::EventLoop<()>, winit::window::Window) {
+    use winit::{event_loop::EventLoop, window::Window};
+
+    let event_loop = EventLoop::new().unwrap();
+
+    #[allow(deprecated)]
+    let window = event_loop
+        .create_window(
+            Window::default_attributes()
+                .with_title("Yakui Vulkan - Test")
+                .with_inner_size(winit::dpi::LogicalSize::new(
+                    f64::from(window_width),
+                    f64::from(window_height),
+                )),
+        )
+        .unwrap();
+    (event_loop, window)
+}
+
+fn create_swapchain(
+    device: &ash::Device,
+    previous_swapchain: Option<vk::SwapchainKHR>,
+    swapchain_info: &SwapchainInfo,
+) -> (vk::SwapchainKHR, Vec<vk::ImageView>) {
+    let SwapchainInfo {
+        swapchain_loader,
+        surface_format,
+        surface_resolution,
+        present_mode,
+        surface,
+        desired_image_count,
+    } = swapchain_info;
+
+    let mut swapchain_create_info = vk::SwapchainCreateInfoKHR::default()
+        .surface(*surface)
+        .min_image_count(*desired_image_count)
+        .image_color_space(surface_format.color_space)
+        .image_format(surface_format.format)
+        .image_extent(*surface_resolution)
+        .image_usage(vk::ImageUsageFlags::COLOR_ATTACHMENT)
+        .image_sharing_mode(vk::SharingMode::EXCLUSIVE)
+        .pre_transform(vk::SurfaceTransformFlagsKHR::IDENTITY)
+        .composite_alpha(vk::CompositeAlphaFlagsKHR::OPAQUE)
+        .present_mode(*present_mode)
+        .clipped(true)
+        .image_array_layers(1);
+
+    if let Some(old_swapchain) = previous_swapchain {
+        swapchain_create_info.old_swapchain = old_swapchain
+    }
+
+    let swapchain = unsafe {
+        swapchain_loader
+            .create_swapchain(&swapchain_create_info, None)
+            .unwrap()
+    };
+
+    let present_images = unsafe { swapchain_loader.get_swapchain_images(swapchain).unwrap() };
+    let present_image_views: Vec<vk::ImageView> = present_images
+        .iter()
+        .map(|&image| {
+            let create_view_info = vk::ImageViewCreateInfo::default()
+                .view_type(vk::ImageViewType::TYPE_2D)
+                .format(surface_format.format)
+                .components(vk::ComponentMapping {
+                    r: vk::ComponentSwizzle::R,
+                    g: vk::ComponentSwizzle::G,
+                    b: vk::ComponentSwizzle::B,
+                    a: vk::ComponentSwizzle::A,
+                })
+                .subresource_range(vk::ImageSubresourceRange {
+                    aspect_mask: vk::ImageAspectFlags::COLOR,
+                    base_mip_level: 0,
+                    level_count: 1,
+                    base_array_layer: 0,
+                    layer_count: 1,
+                })
+                .image(image);
+            unsafe { device.create_image_view(&create_view_info, None).unwrap() }
+        })
+        .collect();
+
+    (swapchain, present_image_views)
+}
+
+impl Drop for VulkanTest {
+    fn drop(&mut self) {
+        unsafe {
+            self.device.device_wait_idle().unwrap();
+            self.device
+                .destroy_semaphore(self.present_complete_semaphore, None);
+            self.device
+                .destroy_semaphore(self.rendering_complete_semaphore, None);
+            self.device
+                .destroy_fence(self.draw_commands_reuse_fence, None);
+            self.device
+                .destroy_fence(self.setup_commands_reuse_fence, None);
+            self.device.destroy_command_pool(self.command_pool, None);
+            self.destroy_swapchain(self.swapchain);
+            self.device.destroy_render_pass(self.render_pass, None);
+            self.device.destroy_device(None);
+            self.surface_loader.destroy_surface(self.surface, None);
+            self.instance.destroy_instance(None);
+        }
+    }
+}
+
+struct SwapchainInfo {
+    pub swapchain_loader: ash::khr::swapchain::Device,
+    pub surface_format: vk::SurfaceFormatKHR,
+    pub surface_resolution: vk::Extent2D,
+    pub present_mode: vk::PresentModeKHR,
+    pub surface: vk::SurfaceKHR,
+    pub desired_image_count: u32,
+}
+
+impl SwapchainInfo {
+    pub fn new(
+        swapchain_loader: ash::khr::swapchain::Device,
+        surface_format: vk::SurfaceFormatKHR,
+        surface_resolution: vk::Extent2D,
+        present_mode: vk::PresentModeKHR,
+        surface: vk::SurfaceKHR,
+        desired_image_count: u32,
+    ) -> Self {
+        Self {
+            swapchain_loader,
+            surface_format,
+            surface_resolution,
+            present_mode,
+            surface,
+            desired_image_count,
+        }
+    }
+}
+
+fn create_framebuffers(
+    views: &[vk::ImageView],
+    extent: vk::Extent2D,
+    render_pass: vk::RenderPass,
+    device: &ash::Device,
+) -> Vec<vk::Framebuffer> {
+    let framebuffers: Vec<vk::Framebuffer> = views
+        .iter()
+        .map(|&present_image_view| {
+            let framebuffer_attachments = [present_image_view];
+            let frame_buffer_create_info = vk::FramebufferCreateInfo::default()
+                .render_pass(render_pass)
+                .attachments(&framebuffer_attachments)
+                .width(extent.width)
+                .height(extent.height)
+                .layers(1);
+
+            unsafe {
+                device
+                    .create_framebuffer(&frame_buffer_create_info, None)
+                    .unwrap()
+            }
+        })
+        .collect();
+    framebuffers
+}

--- a/crates/yakui-vulkan/examples/demo.rs
+++ b/crates/yakui-vulkan/examples/demo.rs
@@ -7,7 +7,7 @@ use winit::{
     event_loop::ControlFlow,
     keyboard::{KeyCode, PhysicalKey},
 };
-use yakui::image;
+use yakui::{image, Rect};
 
 const MONKEY_PNG: &[u8] = include_bytes!("../../bootstrap/assets/monkey.png");
 const DOG_JPG: &[u8] = include_bytes!("../assets/dog.jpg");
@@ -25,7 +25,7 @@ enum WhichImage {
     Dog,
 }
 
-/// Simple smoke test to make sure render screen properly pixel Vulkan.
+/// Simple test to make sure Vulkan backend renders properly.
 fn main() {
     use winit::dpi::PhysicalSize;
 
@@ -35,7 +35,7 @@ fn main() {
 
     let mut yak = yakui::Yakui::new();
     yak.set_surface_size([width as f32, height as f32].into());
-    yak.set_unscaled_viewport(yakui_core::geometry::Rect::from_pos_size(
+    yak.set_unscaled_viewport(Rect::from_pos_size(
         Default::default(),
         [width as f32, height as f32].into(),
     ));
@@ -134,7 +134,7 @@ fn main() {
                 let PhysicalSize { width, height } = size;
                 vulkan_test.resized(width, height);
                 yak.set_surface_size([width as f32, height as f32].into());
-                yak.set_unscaled_viewport(yakui_core::geometry::Rect::from_pos_size(
+                yak.set_unscaled_viewport(Rect::from_pos_size(
                     Default::default(),
                     [width as f32, height as f32].into(),
                 ));

--- a/crates/yakui-vulkan/src/buffer.rs
+++ b/crates/yakui-vulkan/src/buffer.rs
@@ -9,7 +9,7 @@ const MIN_BUFFER_SIZE: vk::DeviceSize = 1_048_576; // 1MB
 ///
 /// May be slightly slow on desktop, but future work could be done to use DEVICE_LOCAL memory if
 /// need be.
-pub(crate) struct Buffer<T> {
+pub struct Buffer<T> {
     pub handle: vk::Buffer,
     pub memory: vk::DeviceMemory,
     pub _usage: vk::BufferUsageFlags,

--- a/crates/yakui-vulkan/src/descriptors.rs
+++ b/crates/yakui-vulkan/src/descriptors.rs
@@ -3,10 +3,11 @@ use ash::vk;
 use crate::vulkan_context::VulkanContext;
 
 /// A thin wrapper around descriptor related functionality
+#[allow(missing_docs)]
 pub struct Descriptors {
     pub(crate) pool: vk::DescriptorPool,
-    pub(crate) set: vk::DescriptorSet,
-    pub(crate) layout: vk::DescriptorSetLayout,
+    pub set: vk::DescriptorSet,
+    pub layout: vk::DescriptorSetLayout,
     texture_count: u32,
 }
 

--- a/crates/yakui-vulkan/src/vulkan_texture.rs
+++ b/crates/yakui-vulkan/src/vulkan_texture.rs
@@ -5,7 +5,8 @@ use yakui_core as yakui;
 
 use crate::{buffer::Buffer, descriptors::Descriptors, vulkan_context::VulkanContext};
 
-pub(crate) const NO_TEXTURE_ID: u32 = u32::MAX;
+/// Special ID used to indicate the lack of texture used.
+pub const NO_TEXTURE_ID: u32 = u32::MAX;
 
 /// A container around a Vulkan created texture
 pub struct VulkanTexture {

--- a/crates/yakui-wgpu/Cargo.toml
+++ b/crates/yakui-wgpu/Cargo.toml
@@ -18,3 +18,12 @@ thunderdome.workspace = true
 wgpu.workspace = true
 
 profiling.workspace = true
+
+
+[dev-dependencies]
+yakui = { path = "../yakui", version = "0.3.0" }
+yakui-winit = { path = "../yakui-winit", version = "0.3.0" }
+
+pollster.workspace = true
+
+winit.workspace = true

--- a/crates/yakui-wgpu/examples/custom_wgpu_renderer.rs
+++ b/crates/yakui-wgpu/examples/custom_wgpu_renderer.rs
@@ -1,0 +1,572 @@
+use std::time::Instant;
+
+use glam::{UVec2, Vec2};
+use thunderdome::{Arena, Index};
+use wgpu::rwh::{HasDisplayHandle, HasWindowHandle};
+use winit::application::ApplicationHandler;
+use winit::event::WindowEvent;
+use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
+use winit::window::{Window, WindowAttributes, WindowId};
+use yakui::paint::{PaintCall, UserPaintCallId};
+use yakui::util::widget;
+use yakui::widget::Widget;
+use yakui::{Color, Yakui};
+use yakui_wgpu::{DrawCall, SurfaceInfo, Vertex};
+use yakui_winit::YakuiWinit;
+
+#[derive(Debug)]
+struct MyCustomRenderer {
+    objects: Arena<MyCustomRenderedObject>,
+    initial_time: Instant,
+}
+
+impl MyCustomRenderer {
+    pub fn add(&mut self, object: MyCustomRenderedObject) -> UserPaintCallId {
+        self.objects.insert(object).to_bits()
+    }
+
+    pub fn clear(&mut self) {
+        self.objects.clear();
+    }
+
+    pub fn new() -> Self {
+        Self {
+            objects: Arena::new(),
+            initial_time: Instant::now(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct MyCustomRenderedObject {
+    color: Color,
+}
+
+impl MyCustomRenderedObject {
+    pub fn show(self) -> yakui::Response<()> {
+        widget::<MyCustomRenderedWidget>(self)
+    }
+}
+
+#[derive(Debug)]
+struct MyCustomRenderedWidget {
+    props: MyCustomRenderedObject,
+}
+
+impl Widget for MyCustomRenderedWidget {
+    type Props<'a> = MyCustomRenderedObject;
+
+    type Response = ();
+
+    fn new() -> Self {
+        Self {
+            props: MyCustomRenderedObject {
+                color: Color::CLEAR,
+            },
+        }
+    }
+
+    fn update(&mut self, props: Self::Props<'_>) -> Self::Response {
+        self.props = props
+    }
+
+    fn layout(
+        &self,
+        ctx: yakui::widget::LayoutContext<'_>,
+        _constraints: yakui::Constraints,
+    ) -> yakui::Vec2 {
+        ctx.layout.enable_clipping(ctx.dom);
+
+        yakui::Vec2::new(80., 80.)
+    }
+
+    fn paint(&self, ctx: yakui::widget::PaintContext<'_>) {
+        let id = ctx
+            .paint
+            .globals
+            .get_mut(MyCustomRenderer::new)
+            .add(self.props);
+
+        ctx.paint.add_user_call(id);
+    }
+}
+
+fn my_custom_paint(
+    yakui_wgpu: &mut yakui_wgpu::YakuiWgpu,
+    state: &mut yakui_core::Yakui,
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    encoder: &mut wgpu::CommandEncoder,
+    surface: SurfaceInfo<'_>,
+) {
+    // --- yakui ---
+    yakui_wgpu.set_paint_limits(state);
+    let paint = state.paint();
+
+    yakui_wgpu.update_textures(device, paint, queue);
+
+    // If there's nothing to paint, well... don't paint!
+    let layers = &paint.layers;
+    if layers.iter().all(|layer| layer.calls.is_empty()) {
+        return;
+    }
+
+    // If the surface has a size of zero, well... don't paint either!
+    if paint.surface_size().x == 0.0 || paint.surface_size().y == 0.0 {
+        return;
+    }
+
+    yakui_wgpu.vertices.clear();
+    yakui_wgpu.indices.clear();
+    yakui_wgpu.texture_bindgroup_cache.clear();
+
+    let mut draw_calls = Vec::with_capacity(layers.len());
+    // --- yakui ---
+
+    let renderer = paint.globals.get_mut(MyCustomRenderer::new);
+
+    let mut custom_draws = Arena::new();
+    let elapsed = Instant::now()
+        .duration_since(renderer.initial_time)
+        .as_secs_f32();
+
+    for (clip, call) in layers.iter().flat_map(|layer| &layer.calls) {
+        match call {
+            PaintCall::Internal(call) => {
+                draw_calls.push(yakui_wgpu.build_draw_call(device, *clip, call));
+            }
+            PaintCall::User(id) => {
+                let min = clip.pos();
+                let max = clip.max();
+
+                let x1y1 = min;
+                let x1y2 = Vec2::new(min.x, max.y);
+                let x2y1 = Vec2::new(max.x, min.y);
+                let x2y2 = max;
+
+                let index = Index::from_bits(*id).unwrap();
+                let object = renderer.objects.get(index).unwrap();
+                let mut color = object.color.to_linear();
+
+                color.x = (color.x + elapsed).sin().abs();
+                color.y = (color.y + elapsed).cos().abs();
+
+                let my_indices = [0, 1, 2, 1, 3, 2];
+
+                let vertices = [x1y1, x1y2, x2y1, x2y2].into_iter().map(|pos| Vertex {
+                    position: paint.info.transform_vertex(pos, false),
+                    texcoord: Vec2::default(),
+                    color,
+                });
+
+                let base = yakui_wgpu.vertices.len() as u32;
+                let indices = my_indices.iter().map(|&index| base + index as u32);
+
+                let start = yakui_wgpu.indices.len() as u32;
+                let end = start + indices.len() as u32;
+
+                yakui_wgpu.vertices.extend(vertices);
+                yakui_wgpu.indices.extend(indices);
+
+                draw_calls.push((*clip, DrawCall::User(*id)));
+                custom_draws.insert_at(index, start..end);
+            }
+        }
+    }
+
+    renderer.clear();
+
+    // --- yakui ---
+    let vertices = yakui_wgpu.vertices.upload(device, queue);
+    let indices = yakui_wgpu.indices.upload(device, queue);
+    // --- yakui ---
+
+    {
+        // --- yakui ---
+        let main_pipeline =
+            yakui_wgpu::main_pipeline(&mut yakui_wgpu.main_pipeline, device, &surface);
+        let text_pipeline =
+            yakui_wgpu::text_pipeline(&mut yakui_wgpu.text_pipeline, device, &surface);
+
+        let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some("yakui Render Pass"),
+            color_attachments: &[Some(surface.color_attachment)],
+            ..Default::default()
+        });
+
+        render_pass.set_vertex_buffer(0, vertices.slice(..));
+        render_pass.set_index_buffer(indices.slice(..), wgpu::IndexFormat::Uint32);
+
+        let surface = paint.surface_size().as_uvec2();
+        render_pass.set_viewport(0.0, 0.0, surface.x as f32, surface.y as f32, 0.0, 1.0);
+
+        let mut last_clip = None;
+        // --- yakui ---
+
+        for (clip, draw_call) in draw_calls {
+            // --- yakui ---
+            if Some(clip) != last_clip {
+                last_clip = Some(clip);
+
+                let surface = paint.surface_size().as_uvec2();
+
+                let pos = clip.pos().as_uvec2();
+                let size = clip.size().as_uvec2();
+
+                let max = (pos + size).min(surface);
+                let size = UVec2::new(max.x.saturating_sub(pos.x), max.y.saturating_sub(pos.y));
+
+                // If the scissor rect isn't valid, we can skip this
+                // entire draw call.
+                if pos.x > surface.x || pos.y > surface.y || size.x == 0 || size.y == 0 {
+                    continue;
+                }
+
+                render_pass.set_scissor_rect(pos.x, pos.y, size.x, size.y);
+            }
+            // --- yakui ---
+
+            match draw_call {
+                DrawCall::Yakui(call) => {
+                    yakui_wgpu::YakuiWgpu::draw_yakui(
+                        &yakui_wgpu.texture_bindgroup_cache,
+                        &mut render_pass,
+                        main_pipeline,
+                        text_pipeline,
+                        call,
+                    );
+                }
+                DrawCall::User(id) => {
+                    let index_range = custom_draws.remove(Index::from_bits(id).unwrap()).unwrap();
+
+                    render_pass.set_bind_group(0, &yakui_wgpu.texture_bindgroup_cache.default, &[]);
+                    render_pass.draw_indexed(index_range, 0, 0..1);
+                }
+            }
+        }
+    }
+}
+
+/// A helper for setting up rendering with winit and wgpu
+pub struct Graphics {
+    pub device: wgpu::Device,
+    pub queue: wgpu::Queue,
+
+    format: wgpu::TextureFormat,
+    surface: wgpu::Surface<'static>,
+    surface_config: wgpu::SurfaceConfiguration,
+    size: UVec2,
+
+    pub renderer: yakui_wgpu::YakuiWgpu,
+}
+
+impl Graphics {
+    pub async fn new<T: HasDisplayHandle + HasWindowHandle>(window: &T, mut size: UVec2) -> Self {
+        // FIXME: On web, we're receiving (0, 0) as the initial size of the
+        // window, which makes wgpu upset. If we hit that case, let's just make
+        // up a size and let it get fixed later.
+        if size == UVec2::new(0, 0) {
+            size = UVec2::new(800, 600);
+        }
+
+        let instance = wgpu::Instance::default();
+        let surface = unsafe {
+            instance.create_surface_unsafe(
+                wgpu::SurfaceTargetUnsafe::from_window(window)
+                    .expect("Could not create wgpu surface from window"),
+            )
+        }
+        .expect("Could not create wgpu surface");
+
+        let adapter = instance
+            .request_adapter(&wgpu::RequestAdapterOptions {
+                power_preference: wgpu::PowerPreference::default(),
+                compatible_surface: Some(&surface),
+                force_fallback_adapter: false,
+            })
+            .await
+            .unwrap();
+
+        let (device, queue) = adapter
+            .request_device(&wgpu::DeviceDescriptor {
+                // WebGL doesn't support all of wgpu's features, so if
+                // we're building for the web we'll have to disable some.
+                required_limits: if cfg!(target_arch = "wasm32") {
+                    wgpu::Limits::downlevel_webgl2_defaults()
+                } else {
+                    wgpu::Limits::default()
+                },
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        let capabilities = surface.get_capabilities(&adapter);
+        let format = capabilities.formats[0];
+        let surface_config = wgpu::SurfaceConfiguration {
+            alpha_mode: wgpu::CompositeAlphaMode::Auto,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+            format,
+            view_formats: Vec::new(),
+            width: size.x,
+            height: size.y,
+            present_mode: wgpu::PresentMode::Fifo,
+            desired_maximum_frame_latency: 2,
+        };
+        surface.configure(&device, &surface_config);
+
+        // yakui_wgpu takes paint output from yakui and renders it for us using
+        // wgpu.
+        let renderer = yakui_wgpu::YakuiWgpu::new(&device, &queue);
+
+        Self {
+            device,
+            queue,
+
+            format,
+            surface,
+            surface_config,
+            size,
+
+            renderer,
+        }
+    }
+
+    pub fn resize(&mut self, new_size: UVec2) {
+        if new_size.x > 0 && new_size.y > 0 && new_size != self.size {
+            self.size = new_size;
+            self.surface_config.width = new_size.x;
+            self.surface_config.height = new_size.y;
+            self.surface.configure(&self.device, &self.surface_config);
+        }
+    }
+
+    #[profiling::function]
+    pub fn paint(&mut self, yak: &mut yakui::Yakui, bg: wgpu::Color) {
+        let output = match self.surface.get_current_texture() {
+            Ok(output) => output,
+            Err(_) => return,
+        };
+
+        let view = output
+            .texture
+            .create_view(&wgpu::TextureViewDescriptor::default());
+
+        let surface = SurfaceInfo {
+            format: self.format,
+            sample_count: 1,
+            color_attachment: wgpu::RenderPassColorAttachment {
+                view: &view,
+                depth_slice: None,
+                resolve_target: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Load,
+                    store: wgpu::StoreOp::Store,
+                },
+            },
+        };
+
+        let mut encoder = self
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("Render Encoder"),
+            });
+
+        {
+            let _render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("Render Pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: surface.color_attachment.view,
+                    depth_slice: None,
+                    resolve_target: surface.color_attachment.resolve_target,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(bg),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                ..Default::default()
+            });
+        }
+
+        let clear = encoder.finish();
+
+        let paint_yak = {
+            let mut encoder = self
+                .device
+                .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                    label: Some("yakui Encoder"),
+                });
+
+            my_custom_paint(
+                &mut self.renderer,
+                yak,
+                &self.device,
+                &self.queue,
+                &mut encoder,
+                surface,
+            );
+
+            encoder.finish()
+        };
+
+        self.queue.submit([clear, paint_yak]);
+        output.present();
+    }
+}
+
+struct App {
+    yak: Yakui,
+    window: Option<Window>,
+    graphics: Option<Graphics>,
+    yak_window: Option<YakuiWinit>,
+}
+
+impl ApplicationHandler for App {
+    // This is a common indicator that you can create a window.
+    fn resumed(&mut self, event_loop: &ActiveEventLoop) {
+        let window = event_loop
+            .create_window(WindowAttributes::default())
+            .unwrap();
+        window.set_ime_allowed(true);
+
+        let size = window.inner_size();
+        let size = UVec2::new(size.width, size.height);
+
+        let graphics = pollster::block_on(Graphics::new(&window, size));
+        let yak_window = yakui_winit::YakuiWinit::new(&window);
+
+        self.window = Some(window);
+        self.graphics = Some(graphics);
+        self.yak_window = Some(yak_window);
+    }
+
+    fn window_event(
+        &mut self,
+        event_loop: &ActiveEventLoop,
+        _window_id: WindowId,
+        event: WindowEvent,
+    ) {
+        if self
+            .yak_window
+            .as_mut()
+            .unwrap()
+            .handle_window_event(&mut self.yak, &event)
+        {
+            return;
+        }
+
+        // Handle window event.
+        match event {
+            WindowEvent::RedrawRequested => {
+                {
+                    profiling::scope!("Build UI");
+
+                    // Every frame, call yak.start() to begin building the UI for
+                    // this frame. Any yakui widget calls that happen on this thread
+                    // between start() and finish() will be applied to this yakui
+                    // State.
+                    self.yak.start();
+
+                    gui();
+
+                    // Finish building the UI and compute this frame's layout.
+                    self.yak.finish();
+                }
+
+                // The example graphics abstraction calls yak.paint() to get
+                // access to the underlying PaintDom, which holds all the state
+                // about how to paint widgets.
+                if let Some(graphics) = self.graphics.as_mut() {
+                    graphics.paint(&mut self.yak, {
+                        let bg = yakui::colors::BACKGROUND_1.to_linear();
+                        wgpu::Color {
+                            r: bg.x.into(),
+                            g: bg.y.into(),
+                            b: bg.z.into(),
+                            a: 1.0,
+                        }
+                    });
+                }
+
+                profiling::finish_frame!();
+
+                self.window.as_ref().unwrap().request_redraw();
+            }
+
+            WindowEvent::MouseInput { state, button, .. } => {
+                // This print is a handy way to show which mouse events are
+                // handled by yakui, and which ones will make it to the
+                // underlying application.
+                if button == winit::event::MouseButton::Left {
+                    println!("Left mouse button {state:?}");
+                }
+            }
+
+            WindowEvent::Resized(..) => {
+                if let Some(graphics) = &mut self.graphics {
+                    graphics.resize(self.yak.surface_size().as_uvec2());
+                }
+            }
+
+            WindowEvent::CloseRequested => {
+                self.graphics = None;
+
+                event_loop.exit();
+            }
+
+            _ => (),
+        }
+    }
+}
+
+/// Simple test to make sure wgpu backend renders properly with a custom renderer.
+fn main() {
+    // Normal winit setup for an EventLoop and Window.
+    let event_loop = EventLoop::new().unwrap();
+
+    // Set up some default state that we'll modify later.
+    let mut app = App {
+        yak: Yakui::new(),
+        window: None,
+        graphics: None,
+        yak_window: None,
+    };
+
+    event_loop.set_control_flow(ControlFlow::Poll);
+
+    event_loop.run_app(&mut app).unwrap();
+}
+
+fn gui() {
+    use yakui::{column, label, row, widgets::Text, Color};
+    column(|| {
+        row(|| {
+            label("Hello, world!");
+
+            let mut text = Text::new(48.0, "colored text!");
+            text.style.color = Color::RED;
+            text.show();
+        });
+
+        row(|| {
+            MyCustomRenderedObject { color: Color::RED }.show();
+            MyCustomRenderedObject {
+                color: Color::GREEN,
+            }
+            .show();
+            MyCustomRenderedObject { color: Color::BLUE }.show();
+            MyCustomRenderedObject {
+                color: Color::YELLOW,
+            }
+            .show();
+            MyCustomRenderedObject {
+                color: Color::WHITE,
+            }
+            .show();
+            MyCustomRenderedObject {
+                color: Color::FUCHSIA,
+            }
+            .show();
+        });
+    });
+}

--- a/crates/yakui-wgpu/src/bindgroup_cache.rs
+++ b/crates/yakui-wgpu/src/bindgroup_cache.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use yakui_core::TextureId;
 
 #[derive(Copy, Clone, Hash, PartialEq, Eq)]
-pub(crate) struct TextureBindgroupCacheEntry {
+pub struct TextureBindgroupCacheEntry {
     pub id: TextureId,
     pub min_filter: wgpu::FilterMode,
     pub mag_filter: wgpu::FilterMode,
@@ -11,7 +11,7 @@ pub(crate) struct TextureBindgroupCacheEntry {
     pub address_mode: wgpu::AddressMode,
 }
 
-pub(crate) struct TextureBindgroupCache {
+pub struct TextureBindgroupCache {
     cache: HashMap<TextureBindgroupCacheEntry, wgpu::BindGroup>,
     layout: wgpu::BindGroupLayout,
     pub default: wgpu::BindGroup,
@@ -30,7 +30,7 @@ impl TextureBindgroupCache {
         self.cache.clear();
     }
 
-    pub fn update(
+    pub(crate) fn update(
         &mut self,
         device: &wgpu::Device,
         entry: TextureBindgroupCacheEntry,

--- a/crates/yakui-wgpu/src/lib.rs
+++ b/crates/yakui-wgpu/src/lib.rs
@@ -44,8 +44,7 @@ pub struct YakuiWgpu {
 pub struct SurfaceInfo<'a> {
     pub format: wgpu::TextureFormat,
     pub sample_count: u32,
-    pub color_attachment: &'a wgpu::TextureView,
-    pub resolve_target: Option<&'a wgpu::TextureView>,
+    pub color_attachment: wgpu::RenderPassColorAttachment<'a>,
 }
 
 #[derive(Debug, Clone, Copy, Zeroable, Pod)]
@@ -234,15 +233,7 @@ impl YakuiWgpu {
         {
             let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                 label: Some("yakui Render Pass"),
-                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                    view: surface.color_attachment,
-                    depth_slice: None,
-                    resolve_target: surface.resolve_target,
-                    ops: wgpu::Operations {
-                        load: wgpu::LoadOp::Load,
-                        store: wgpu::StoreOp::Store,
-                    },
-                })],
+                color_attachments: &[Some(surface.color_attachment)],
                 ..Default::default()
             });
 

--- a/crates/yakui-wgpu/src/lib.rs
+++ b/crates/yakui-wgpu/src/lib.rs
@@ -236,6 +236,7 @@ impl YakuiWgpu {
                 label: Some("yakui Render Pass"),
                 color_attachments: &[Some(wgpu::RenderPassColorAttachment {
                     view: surface.color_attachment,
+                    depth_slice: None,
                     resolve_target: surface.resolve_target,
                     ops: wgpu::Operations {
                         load: wgpu::LoadOp::Load,

--- a/crates/yakui-wgpu/src/lib.rs
+++ b/crates/yakui-wgpu/src/lib.rs
@@ -17,8 +17,11 @@ use bytemuck::{Pod, Zeroable};
 use glam::UVec2;
 use thunderdome::{Arena, Index};
 use yakui_core::geometry::{Rect, Vec2, Vec4};
-use yakui_core::paint::{PaintDom, PaintLimits, Pipeline, Texture, TextureChange, TextureFormat};
-use yakui_core::{ManagedTextureId, TextureId};
+use yakui_core::paint::{
+    PaintCall, PaintDom, PaintLimits, Pipeline, Texture, TextureChange, TextureFormat,
+    UserPaintCallId, Vertex as YakuiVertex, YakuiPaintCall,
+};
+use yakui_core::{ManagedTextureId, TextureId, Yakui};
 
 use self::bindgroup_cache::TextureBindgroupCache;
 use self::bindgroup_cache::TextureBindgroupCacheEntry;
@@ -26,18 +29,30 @@ use self::pipeline_cache::PipelineCache;
 use self::samplers::Samplers;
 use self::texture::{GpuManagedTexture, GpuTexture};
 
+pub struct YakuiDrawCall {
+    pub index_range: Range<u32>,
+    pub bind_group_entry: Option<TextureBindgroupCacheEntry>,
+    pub pipeline: Pipeline,
+}
+
+pub enum DrawCall {
+    Yakui(YakuiDrawCall),
+    User(UserPaintCallId),
+}
+
 pub struct YakuiWgpu {
-    limits: PaintLimits,
-    main_pipeline: PipelineCache,
-    text_pipeline: PipelineCache,
+    pub limits: PaintLimits,
+
+    pub main_pipeline: PipelineCache,
+    pub text_pipeline: PipelineCache,
+
     samplers: Samplers,
     textures: Arena<GpuTexture>,
     managed_textures: HashMap<ManagedTextureId, GpuManagedTexture>,
-    texture_bindgroup_cache: TextureBindgroupCache,
+    pub texture_bindgroup_cache: TextureBindgroupCache,
 
-    vertices: Buffer,
-    indices: Buffer,
-    commands: Vec<DrawCommand>,
+    pub vertices: Buffer,
+    pub indices: Buffer,
 }
 
 #[derive(Debug, Clone)]
@@ -47,12 +62,22 @@ pub struct SurfaceInfo<'a> {
     pub color_attachment: wgpu::RenderPassColorAttachment<'a>,
 }
 
-#[derive(Debug, Clone, Copy, Zeroable, Pod)]
 #[repr(C)]
-struct Vertex {
-    pos: Vec2,
-    texcoord: Vec2,
-    color: Vec4,
+#[derive(Debug, Clone, Copy, Zeroable, Pod)]
+pub struct Vertex {
+    pub position: Vec2,
+    pub texcoord: Vec2,
+    pub color: Vec4,
+}
+
+impl From<&YakuiVertex> for Vertex {
+    fn from(y: &YakuiVertex) -> Self {
+        Self {
+            position: y.position,
+            texcoord: y.texcoord,
+            color: y.color,
+        }
+    }
 }
 
 impl Vertex {
@@ -60,9 +85,9 @@ impl Vertex {
         array_stride: size_of::<Self>() as u64,
         step_mode: wgpu::VertexStepMode::Vertex,
         attributes: &wgpu::vertex_attr_array![
-            0 => Float32x2,
-            1 => Float32x2,
-            2 => Float32x4,
+        0 => Float32x2,
+        1 => Float32x2,
+        2 => Float32x4,
         ],
     };
 }
@@ -140,8 +165,11 @@ impl YakuiWgpu {
             texture_bindgroup_cache: TextureBindgroupCache::new(layout, default_bindgroup),
             vertices: Buffer::new(wgpu::BufferUsages::VERTEX),
             indices: Buffer::new(wgpu::BufferUsages::INDEX),
-            commands: Vec::new(),
         }
+    }
+
+    pub fn set_paint_limits(&self, state: &mut Yakui) {
+        state.set_paint_limit(self.limits);
     }
 
     /// Creates a `TextureId` from an existing wgpu texture that then be used by
@@ -186,7 +214,7 @@ impl YakuiWgpu {
     #[must_use = "YakuiWgpu::paint returns a command buffer which MUST be submitted to wgpu."]
     pub fn paint(
         &mut self,
-        state: &mut yakui_core::Yakui,
+        state: &mut Yakui,
         device: &wgpu::Device,
         queue: &wgpu::Queue,
         surface: SurfaceInfo<'_>,
@@ -202,7 +230,7 @@ impl YakuiWgpu {
 
     pub fn paint_with_encoder(
         &mut self,
-        state: &mut yakui_core::Yakui,
+        state: &mut Yakui,
         device: &wgpu::Device,
         queue: &wgpu::Queue,
         encoder: &mut wgpu::CommandEncoder,
@@ -210,186 +238,108 @@ impl YakuiWgpu {
     ) {
         profiling::scope!("yakui-wgpu paint_with_encoder");
 
-        state.set_paint_limit(self.limits);
-        let paint = state.paint();
-
-        self.update_textures(device, paint, queue);
-
-        let layers = paint.layers();
-        if layers.iter().all(|layer| layer.calls.is_empty()) {
-            return;
-        }
-
-        self.update_buffers(device, paint);
-
-        let vertices = self.vertices.upload(device, queue);
-        let indices = self.indices.upload(device, queue);
-        let commands = &self.commands;
-
-        if paint.surface_size() == Vec2::ZERO {
-            return;
-        }
-
-        {
-            let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                label: Some("yakui Render Pass"),
-                color_attachments: &[Some(surface.color_attachment)],
-                ..Default::default()
-            });
-
-            render_pass.set_vertex_buffer(0, vertices.slice(..));
-            render_pass.set_index_buffer(indices.slice(..), wgpu::IndexFormat::Uint32);
-
-            let mut last_clip = None;
-
-            let main_pipeline = self.main_pipeline.get(
-                device,
-                surface.format,
-                surface.sample_count,
-                make_main_pipeline,
-            );
-
-            let text_pipeline = self.text_pipeline.get(
-                device,
-                surface.format,
-                surface.sample_count,
-                make_text_pipeline,
-            );
-
-            for command in commands {
-                match command.pipeline {
-                    Pipeline::Main => render_pass.set_pipeline(main_pipeline),
-                    Pipeline::Text => render_pass.set_pipeline(text_pipeline),
-                }
-
-                if command.clip != last_clip {
-                    last_clip = command.clip;
-
-                    let surface = paint.surface_size().as_uvec2();
-
-                    match command.clip {
-                        Some(rect) => {
-                            let pos = rect.pos().as_uvec2();
-                            let size = rect.size().as_uvec2();
-
-                            let max = (pos + size).min(surface);
-                            let size = UVec2::new(
-                                max.x.saturating_sub(pos.x),
-                                max.y.saturating_sub(pos.y),
-                            );
-
-                            // If the scissor rect isn't valid, we can skip this
-                            // entire draw call.
-                            if pos.x > surface.x || pos.y > surface.y || size.x == 0 || size.y == 0
-                            {
-                                continue;
-                            }
-
-                            render_pass.set_scissor_rect(pos.x, pos.y, size.x, size.y);
-                        }
-                        None => {
-                            render_pass.set_scissor_rect(0, 0, surface.x, surface.y);
-                        }
-                    }
-                }
-
-                let bindgroup = command
-                    .bind_group_entry
-                    .map(|entry| self.texture_bindgroup_cache.get(&entry))
-                    .unwrap_or(&self.texture_bindgroup_cache.default);
-
-                render_pass.set_bind_group(0, bindgroup, &[]);
-                render_pass.draw_indexed(command.index_range.clone(), 0, 0..1);
-            }
-        }
+        crate::paint(self, state, device, queue, encoder, surface)
     }
 
-    fn update_buffers(&mut self, device: &wgpu::Device, paint: &PaintDom) {
-        profiling::scope!("update_buffers");
+    pub fn build_draw_call(
+        &mut self,
+        device: &wgpu::Device,
+        clip: Rect,
+        call: &YakuiPaintCall,
+    ) -> (Rect, DrawCall) {
+        let vertices = call.vertices.iter().map(Vertex::from);
 
-        self.vertices.clear();
-        self.indices.clear();
-        self.commands.clear();
-        self.texture_bindgroup_cache.clear();
+        let base = self.vertices.len() as u32;
+        let indices = call.indices.iter().map(|&index| base + index as u32);
 
-        let commands = paint
-            .layers()
-            .iter()
-            .flat_map(|layer| &layer.calls)
-            .map(|call| {
-                let vertices = call.vertices.iter().map(|vertex| Vertex {
-                    pos: vertex.position,
-                    texcoord: vertex.texcoord,
-                    color: vertex.color,
-                });
+        let start = self.indices.len() as u32;
+        let end = start + indices.len() as u32;
 
-                let base = self.vertices.len() as u32;
-                let indices = call.indices.iter().map(|&index| base + index as u32);
+        self.vertices.extend(vertices);
+        self.indices.extend(indices);
 
-                let start = self.indices.len() as u32;
-                let end = start + indices.len() as u32;
-
-                self.vertices.extend(vertices);
-                self.indices.extend(indices);
-
-                let bind_group_entry = call
-                    .texture
-                    .and_then(|id| match id {
-                        TextureId::Managed(managed) => {
-                            let texture = self.managed_textures.get(&managed)?;
-                            Some((
-                                id,
-                                &texture.view,
-                                texture.min_filter,
-                                texture.mag_filter,
-                                wgpu::FilterMode::Nearest,
-                                texture.address_mode,
-                            ))
-                        }
-                        TextureId::User(bits) => {
-                            let index = Index::from_bits(bits)?;
-                            let texture = self.textures.get(index)?;
-                            Some((
-                                id,
-                                &texture.view,
-                                texture.min_filter,
-                                texture.mag_filter,
-                                texture.mipmap_filter,
-                                texture.address_mode,
-                            ))
-                        }
-                    })
-                    .map(
-                        |(id, view, min_filter, mag_filter, mipmap_filter, address_mode)| {
-                            let entry = TextureBindgroupCacheEntry {
-                                id,
-                                min_filter,
-                                mag_filter,
-                                mipmap_filter,
-                                address_mode,
-                            };
-                            self.texture_bindgroup_cache.update(
-                                device,
-                                entry,
-                                view,
-                                &self.samplers,
-                            );
-                            entry
-                        },
-                    );
-
-                DrawCommand {
-                    index_range: start..end,
-                    bind_group_entry,
-                    pipeline: call.pipeline,
-                    clip: call.clip,
+        let bind_group_entry = call
+            .texture
+            .and_then(|id| match id {
+                TextureId::Managed(managed) => {
+                    let texture = self.managed_textures.get(&managed)?;
+                    Some((
+                        id,
+                        &texture.view,
+                        texture.min_filter,
+                        texture.mag_filter,
+                        wgpu::FilterMode::Nearest,
+                        texture.address_mode,
+                    ))
                 }
-            });
+                TextureId::User(bits) => {
+                    let index = Index::from_bits(bits)?;
+                    let texture = self.textures.get(index)?;
+                    Some((
+                        id,
+                        &texture.view,
+                        texture.min_filter,
+                        texture.mag_filter,
+                        texture.mipmap_filter,
+                        texture.address_mode,
+                    ))
+                }
+            })
+            .map(
+                |(id, view, min_filter, mag_filter, mipmap_filter, address_mode)| {
+                    let entry = TextureBindgroupCacheEntry {
+                        id,
+                        min_filter,
+                        mag_filter,
+                        mipmap_filter,
+                        address_mode,
+                    };
+                    self.texture_bindgroup_cache
+                        .update(device, entry, view, &self.samplers);
 
-        self.commands.extend(commands);
+                    entry
+                },
+            );
+
+        (
+            clip,
+            DrawCall::Yakui(YakuiDrawCall {
+                index_range: start..end,
+                bind_group_entry,
+                pipeline: call.pipeline,
+            }),
+        )
     }
 
-    fn update_textures(&mut self, device: &wgpu::Device, paint: &PaintDom, queue: &wgpu::Queue) {
+    pub fn draw_yakui(
+        texture_bindgroup_cache: &TextureBindgroupCache,
+        render_pass: &mut wgpu::RenderPass,
+        main_pipeline: &wgpu::RenderPipeline,
+        text_pipeline: &wgpu::RenderPipeline,
+        call: YakuiDrawCall,
+    ) {
+        profiling::scope!("yakui-wgpu draw_yakui");
+
+        match call.pipeline {
+            Pipeline::Main => render_pass.set_pipeline(main_pipeline),
+            Pipeline::Text => render_pass.set_pipeline(text_pipeline),
+        }
+
+        let bindgroup = call
+            .bind_group_entry
+            .map(|entry| texture_bindgroup_cache.get(&entry))
+            .unwrap_or(&texture_bindgroup_cache.default);
+
+        render_pass.set_bind_group(0, bindgroup, &[]);
+        render_pass.draw_indexed(call.index_range.clone(), 0, 0..1);
+    }
+
+    pub fn update_textures(
+        &mut self,
+        device: &wgpu::Device,
+        paint: &PaintDom,
+        queue: &wgpu::Queue,
+    ) {
         profiling::scope!("update_textures");
 
         for (id, texture) in paint.textures() {
@@ -419,13 +369,6 @@ impl YakuiWgpu {
             }
         }
     }
-}
-
-struct DrawCommand {
-    index_range: Range<u32>,
-    bind_group_entry: Option<TextureBindgroupCacheEntry>,
-    pipeline: Pipeline,
-    clip: Option<Rect>,
 }
 
 fn make_main_pipeline(
@@ -524,4 +467,139 @@ fn make_text_pipeline(
         multiview: None,
         cache: None,
     })
+}
+
+pub fn main_pipeline<'a>(
+    main_pipeline: &'a mut PipelineCache,
+    device: &wgpu::Device,
+    surface: &SurfaceInfo<'_>,
+) -> &'a wgpu::RenderPipeline {
+    main_pipeline.get(
+        device,
+        surface.format,
+        surface.sample_count,
+        make_main_pipeline,
+    )
+}
+
+pub fn text_pipeline<'a>(
+    text_pipeline: &'a mut PipelineCache,
+    device: &wgpu::Device,
+    surface: &SurfaceInfo<'_>,
+) -> &'a wgpu::RenderPipeline {
+    text_pipeline.get(
+        device,
+        surface.format,
+        surface.sample_count,
+        make_text_pipeline,
+    )
+}
+
+pub fn paint(
+    yakui_wgpu: &mut YakuiWgpu,
+    state: &mut Yakui,
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    encoder: &mut wgpu::CommandEncoder,
+    surface: SurfaceInfo<'_>,
+) {
+    // --- yakui ---
+    yakui_wgpu.set_paint_limits(state);
+    let paint = state.paint();
+
+    yakui_wgpu.update_textures(device, paint, queue);
+
+    // If there's nothing to paint, well... don't paint!
+    let layers = &paint.layers;
+    if layers.iter().all(|layer| layer.calls.is_empty()) {
+        return;
+    }
+
+    // If the surface has a size of zero, well... don't paint either!
+    if paint.surface_size().x == 0.0 || paint.surface_size().y == 0.0 {
+        return;
+    }
+
+    yakui_wgpu.vertices.clear();
+    yakui_wgpu.indices.clear();
+    yakui_wgpu.texture_bindgroup_cache.clear();
+
+    let mut draw_calls = Vec::with_capacity(layers.len());
+    // --- yakui ---
+
+    for (clip, call) in layers.iter().flat_map(|layer| &layer.calls) {
+        match call {
+            PaintCall::Internal(call) => {
+                draw_calls.push(yakui_wgpu.build_draw_call(device, *clip, call));
+            }
+            PaintCall::User(_) => {
+                panic!("yakui does not handle User PaintCall's by default. Please set up your own rendering logic instead.");
+            }
+        }
+    }
+
+    // --- yakui ---
+    let vertices = yakui_wgpu.vertices.upload(device, queue);
+    let indices = yakui_wgpu.indices.upload(device, queue);
+    // --- yakui ---
+
+    {
+        // --- yakui ---
+        let main_pipeline = main_pipeline(&mut yakui_wgpu.main_pipeline, device, &surface);
+        let text_pipeline = text_pipeline(&mut yakui_wgpu.text_pipeline, device, &surface);
+
+        let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some("yakui Render Pass"),
+            color_attachments: &[Some(surface.color_attachment)],
+            ..Default::default()
+        });
+
+        render_pass.set_vertex_buffer(0, vertices.slice(..));
+        render_pass.set_index_buffer(indices.slice(..), wgpu::IndexFormat::Uint32);
+
+        let surface = paint.surface_size().as_uvec2();
+        render_pass.set_viewport(0.0, 0.0, surface.x as f32, surface.y as f32, 0.0, 1.0);
+
+        let mut last_clip = None;
+        // --- yakui ---
+
+        for (clip, draw_call) in draw_calls {
+            // --- yakui ---
+            if Some(clip) != last_clip {
+                last_clip = Some(clip);
+
+                let surface = paint.surface_size().as_uvec2();
+
+                let pos = clip.pos().as_uvec2();
+                let size = clip.size().as_uvec2();
+
+                let max = (pos + size).min(surface);
+                let size = UVec2::new(max.x.saturating_sub(pos.x), max.y.saturating_sub(pos.y));
+
+                // If the scissor rect isn't valid, we can skip this
+                // entire draw call.
+                if pos.x > surface.x || pos.y > surface.y || size.x == 0 || size.y == 0 {
+                    continue;
+                }
+
+                render_pass.set_scissor_rect(pos.x, pos.y, size.x, size.y);
+            }
+            // --- yakui ---
+
+            match draw_call {
+                DrawCall::Yakui(call) => {
+                    YakuiWgpu::draw_yakui(
+                        &yakui_wgpu.texture_bindgroup_cache,
+                        &mut render_pass,
+                        main_pipeline,
+                        text_pipeline,
+                        call,
+                    );
+                }
+                DrawCall::User(_) => {
+                    panic!("yakui does not handle User PaintCall's by default. Please set up your own rendering logic instead.");
+                }
+            }
+        }
+    }
 }

--- a/crates/yakui-widgets/src/widgets/reflow.rs
+++ b/crates/yakui-widgets/src/widgets/reflow.rs
@@ -64,6 +64,9 @@ impl Widget for ReflowWidget {
     }
 
     fn layout(&self, mut ctx: LayoutContext<'_>, _constraints: Constraints) -> Vec2 {
+        ctx.layout.new_layer(ctx.dom);
+        ctx.layout.escape_clipping(ctx.dom);
+
         let node = ctx.dom.get_current();
         let mut size = Vec2::ZERO;
         for &child in &node.children {

--- a/crates/yakui/examples/test_issue_149.rs
+++ b/crates/yakui/examples/test_issue_149.rs
@@ -1,0 +1,51 @@
+use yakui::widgets::Scrollable;
+use yakui::{
+    button, column, constrained, label, reflow, row, use_state, Alignment, Constraints, Dim2,
+    Pivot, Vec2,
+};
+
+// Demonstrates bug https://github.com/SecondHalfGames/yakui/issues/149
+pub fn run() {
+    let buttons = ["Hello", "World", "Foobar", "Aaaggh", "Badonka", "Hachinka"];
+    let open = use_state(|| true);
+
+    constrained(Constraints::loose(Vec2::new(f32::INFINITY, 138.0)), || {
+        Scrollable::vertical().show(|| {
+            column(|| {
+                row(|| {
+                    button("pushing things to the side");
+
+                    column(|| {
+                        if button("toggle list").clicked {
+                            open.modify(|v| !v);
+                        }
+
+                        if open.get() {
+                            reflow(Alignment::BOTTOM_LEFT, Pivot::TOP_LEFT, Dim2::ZERO, || {
+                                constrained(
+                                    Constraints::loose(Vec2::new(f32::INFINITY, 160.0)),
+                                    || {
+                                        Scrollable::vertical().show(|| {
+                                            column(|| {
+                                                for option in buttons.iter() {
+                                                    button(*option);
+                                                }
+                                            });
+                                        });
+                                    },
+                                );
+                            });
+                        }
+                    });
+                });
+
+                label("the text below is gonna be\n clipped aaaaa                                  oh hi");
+                label("this text\nis gonna\noverflow aaaa");
+            });
+        });
+    });
+}
+
+fn main() {
+    bootstrap::start(run as fn());
+}

--- a/crates/yakui/examples/tooltip.rs
+++ b/crates/yakui/examples/tooltip.rs
@@ -1,0 +1,179 @@
+use core::cell::Cell;
+
+use yakui::event::{EventInterest, EventResponse, WidgetEvent};
+use yakui::layout::{AbstractClipRect, ClipLogic};
+use yakui::util::widget;
+use yakui::widget::{EventContext, LayoutContext, Widget};
+use yakui::widgets::List;
+use yakui::{
+    button, colored_box_container, column, constrained, label, Alignment, Color, Constraints, Dim2,
+    Flow, MainAxisSize, Pivot, Response, Vec2,
+};
+
+#[derive(Debug)]
+struct Tooltip {
+    text: String,
+    show: bool,
+}
+
+impl Tooltip {
+    pub fn show(self) -> Response<()> {
+        widget::<TooltipWidget>(self)
+    }
+}
+
+#[derive(Debug)]
+struct InnerTooltipWidget {}
+
+impl Widget for InnerTooltipWidget {
+    type Props<'a> = String;
+
+    type Response = ();
+
+    fn new() -> Self {
+        Self {}
+    }
+
+    fn update(&mut self, props: Self::Props<'_>) -> Self::Response {
+        colored_box_container(Color::BLACK, || {
+            label(props);
+        });
+    }
+
+    fn layout(&self, ctx: LayoutContext<'_>, constraints: Constraints) -> Vec2 {
+        ctx.layout.set_clip_logic(
+            ctx.dom,
+            ClipLogic::Contain {
+                it: AbstractClipRect::LayoutRect,
+                parent: AbstractClipRect::ParentRect,
+            },
+        );
+
+        self.default_layout(ctx, constraints)
+    }
+}
+
+#[derive(Debug)]
+struct TooltipWidget {
+    pos: Cell<Vec2>,
+    offset: Cell<Vec2>,
+    size: Cell<Vec2>,
+    show: bool,
+}
+
+impl Widget for TooltipWidget {
+    type Props<'a> = Tooltip;
+
+    type Response = ();
+
+    fn new() -> Self {
+        Self {
+            pos: Cell::default(),
+            offset: Cell::default(),
+            size: Cell::default(),
+            show: false,
+        }
+    }
+
+    fn event_interest(&self) -> EventInterest {
+        EventInterest::MOUSE_ALL
+    }
+
+    fn event(&mut self, _ctx: EventContext<'_>, event: &WidgetEvent) -> EventResponse {
+        match event {
+            WidgetEvent::MouseMoved(Some(pos)) => {
+                self.pos.set(*pos);
+
+                EventResponse::Bubble
+            }
+            _ => EventResponse::Bubble,
+        }
+    }
+
+    fn flow(&self) -> Flow {
+        let offset = self.offset.get();
+
+        Flow::Relative {
+            anchor: Alignment::TOP_LEFT,
+            offset: Dim2::pixels(offset.x, offset.y),
+        }
+    }
+
+    fn update(&mut self, props: Self::Props<'_>) -> Self::Response {
+        self.show = props.show;
+
+        let mut container = List::row();
+        container.main_axis_size = MainAxisSize::Min;
+
+        container.show(|| {
+            colored_box_container(Color::BLACK, || {
+                label(props.text);
+            });
+        });
+    }
+
+    fn paint(&self, ctx: yakui::widget::PaintContext<'_>) {
+        if self.show {
+            self.default_paint(ctx);
+        }
+    }
+
+    fn layout(&self, ctx: LayoutContext<'_>, constraints: Constraints) -> Vec2 {
+        ctx.layout.set_clip_logic(
+            ctx.dom,
+            ClipLogic::Contain {
+                it: AbstractClipRect::LayoutRect,
+                parent: AbstractClipRect::ParentRect,
+            },
+        );
+
+        {
+            let size = self.size.get();
+            let pos = self.pos.get();
+
+            if size != Vec2::ZERO {
+                if let Some(parent) = ctx
+                    .dom
+                    .get_current()
+                    .parent
+                    .and_then(|id| ctx.layout.get(id))
+                {
+                    self.offset
+                        .set(pos - parent.rect.pos() - size * Pivot::TOP_CENTER.as_vec2());
+                }
+            }
+        }
+
+        let size = self.default_layout(ctx, constraints);
+        self.size.set(size);
+        size
+    }
+}
+
+pub fn run() {
+    static TOOLTIP: &str =
+        "reference: 'yak song' by Vylet Pony. haha get it, yak? yakui? fine okay.";
+
+    column(|| {
+        constrained(Constraints::tight(Vec2::new(800.0, 400.0)), || {
+            colored_box_container(Color::GRAY, || {
+                column(|| {
+                    label("hiiiiiii, hover over the button below for a helpful tooltip!!! <3");
+
+                    let hovering =
+                        button("ill never sing yak song like my father before me").hovering;
+
+                    Tooltip {
+                        text: TOOLTIP.to_string(),
+                        show: hovering,
+                    }
+                    .show();
+                });
+            });
+        });
+    });
+}
+
+fn main() {
+    bootstrap::start(run as fn());
+}


### PR DESCRIPTION
First of all: Credit of the API proposal goes to @HexyWitch!
This PR is loosely based on #171 and her implementation of the proposed API in her own branch.
Lemme know if you want to be added to the co-authors for these commits :purple_heart:.

Second of all: This PR depends on #210
The clipping rect rework simplifies a lot of changes introduced in this PR, so it'd be nice to get that merged first. As such, this PR will be a draft PR until then.

---

So, there are some rationales needing explanation in this PR.

- The `paint()` function in the rendering backends are supposed to be entirely copied to the user's own codebase, and as such, the function should be easy to copy over, and nothing else should need to be copied, everything needed has been publicised.
    - And so, there are now some `// --- yakui ---` sprinkled throughout the `paint()` functions that declare "this part of the code came from copying yakui's official rendering code".
    - The point is to allow users to easily know which parts are not their own code, and therefore can be copied from upstream wholly if it's changed. This also means that any changes to code inside of those comments will be considered API-changing.
    - Most new functions added are to allow people to not need to copy some other code to make their own custom paint function work.
- There are now global states in `PaintDom`, as well as a struct called `Globals`, a struct called `PaintInfo`, a few new functions to lift common functionality out, and removals of some functions in favour of Just Using The Field Directly, to accompany this change.
    - The reason is that- when we were writing the example code for the wgpu backend, we discovered that putting the custom renderer state into `Dom`'s globals and therefore introducing a `Rc<RefCell<T>>` in there- that created a really hard to spot footgun!
    - And so, we've made it so that you should put the custom renderer state into `PaintDom` and mutably borrow the global out of `PaintDom` when painting.
    - And this complicated things! Because partial borrows can't be detected when the field is exposed via a method.
    - And so, we've made the fields public instead and axed the functions that previously exposed them.
- The clipping rect is now exposed directly to the user as well, instead of being stored in yakui's own PaintCall type. This is why the clipping rect rework is a dependency.

---

We've also changed a few comments here and there that weren't lining up with other comments of the same type, and we also reorganised a few functions to be next to each other.
We've also added a debug assertion to check if `PaintDom::paint_all` was called more than once a frame, because, well, you shouldn't do that!
