### PR TITLE
Limit text atlas to 4096^2

### DIFF
--- a/crates/yakui-widgets/src/text_renderer.rs
+++ b/crates/yakui-widgets/src/text_renderer.rs
@@ -57,7 +57,7 @@ impl InnerAtlas {
     }
 
     fn ensure_texture(&mut self, paint: &mut PaintDom) -> Option<ManagedTextureId> {
-        let texture_size = paint.limits()?.max_texture_size_2d;
+        let texture_size = paint.limits()?.max_texture_size_2d.min(4096);
 
         if self.texture.is_none() {
             let mut texture = Texture::new(


### PR DESCRIPTION
Previously, the text rendering code would make the atlas as big as the GPU allowed. On modern cards this is 32k x 32k, so 4 bytes + 1 byte of mask atlas would end up at 5gb of texture data