### PR TITLE
Expose `bind_dom` and `unbind_dom` for hot reloading

### DIFF
--- a/crates/yakui-core/src/context.rs
+++ b/crates/yakui-core/src/context.rs
@@ -20,11 +20,19 @@ pub fn dom() -> Ref<'static, Dom> {
     borrow(&CURRENT_DOM)
 }
 
-pub(crate) fn bind_dom(dom: &Dom) {
+/// Binds a DOM on the current thread.
+///
+/// # Panics
+/// Panics if there is already a DOM being updated on this thread.
+pub fn bind_dom(dom: &Dom) {
     bind(&CURRENT_DOM, dom.clone());
 }
 
-pub(crate) fn unbind_dom() {
+/// Unbinds the DOM on the current thread.
+///
+/// # Panics
+/// Panics if there is no DOM currently being updated on this thread.
+pub fn unbind_dom() {
     unbind(&CURRENT_DOM);
 }
 

--- a/crates/yakui-core/src/state.rs
+++ b/crates/yakui-core/src/state.rs
@@ -127,6 +127,11 @@ impl Yakui {
         &self.layout
     }
 
+    /// Returns access to the state's Paint DOM.
+    pub fn paint_dom(&self) -> &PaintDom {
+        &self.paint
+    }
+
     /// Sets the paint limits, should be called once by rendering backends.
     pub fn set_paint_limit(&mut self, limits: PaintLimits) {
         self.paint.set_limit(limits)


### PR DESCRIPTION
Here comes another niche use case!

Something I've found really useful for iterating on yakui UIs is hot-reloading. Compiling all the yakui code in a separate crate and loading it as a DLL during development provides for a really great development experience.

However, this does rely on exposing some of yakui's internals, which feels a little gross. The function executed in the DLL must do something like the following in order to make sure that the DOM is available at the time any yakui-related code is invoked:

```rust
pub fn gui(dom: &yakui::dom::Dom, state: EditorState, _registry: &ComponentRegistry) {
    yakui::context::bind_dom(dom);

    gui_inner(state);

    yakui::context::unbind_dom();
}
```

(you can find a more complex example in an application that uses this system in anger [here](https://github.com/leetvr/lazy_engine/blob/82e1a171e1205ab745cd6660c064328aeb05132f/bonk_gui/src/lib.rs#L12))

DLL hot-reloading in Rust is still a niche thing. [60% of the time it works every time](https://www.youtube.com/watch?v=pjvQFtlNQ-M), but when it works, it works *so good*. It would be great for yakui to support that use case!

If there's another way this should be implemented, let me know! This was just my first pass that happened to work.