### PR TITLE
make the primitive vertex repr C

### DIFF
--- a/crates/yakui-core/src/paint/primitives.rs
+++ b/crates/yakui-core/src/paint/primitives.rs
@@ -53,6 +53,7 @@ impl PaintCall {
 
 #[derive(Debug, Clone, Copy)]
 #[allow(missing_docs)]
+#[repr(C)]
 pub struct Vertex {
     pub position: Vec2,
     pub texcoord: Vec2,


### PR DESCRIPTION
The primitive `Vertex` is not repr C, so all implementations need to convert it to a local type. I think this is *on purpose*, but after years of the repo being out, I think it's reasonable to just allow users to work with the primitive type. That nicely allows users to take the draw list that yakui makes and, without making a copy, send that directly to the GPU.

Ultimately, making it reprC or not does not change our ability to allow or prevent users from using the primitive vertex in their rendering code -- it just allows it to be more correct if they do it, which I think is a win.

If we embrace this pattern, which i think we should, we can also delete the vulkan and wgpu `Vertex`; or rather, we can replace them with:

```
#[repr(transparent)]
struct VulkanVertex(yakui::paint::Vertex);
```
and then just cast the slice of yakui::paint::Vertex to the `VulkanVertex`.