### PR TITLE
Return `Dom` clone instead of extending lifetime

### DIFF
--- a/crates/yakui-core/src/context.rs
+++ b/crates/yakui-core/src/context.rs
@@ -1,6 +1,6 @@
 //! Provides access to the currently active DOM.
 
-use std::cell::{Ref, RefCell};
+use std::cell::RefCell;
 use std::thread::LocalKey;
 
 use crate::dom::Dom;
@@ -11,13 +11,18 @@ thread_local! {
     static CURRENT_DOM: Storage<Dom> = const { RefCell::new(None) };
 }
 
-/// If there is a DOM currently being updated on this thread, returns a
-/// reference to it.
+/// If there is a DOM currently being updated on this thread, returns a handle
+/// to it.
 ///
 /// # Panics
 /// Panics if there is no DOM currently being updated on this thread.
-pub fn dom() -> Ref<'static, Dom> {
-    borrow(&CURRENT_DOM)
+pub fn dom() -> Dom {
+    CURRENT_DOM.with_borrow(|context| {
+        context
+            .as_ref()
+            .unwrap_or_else(|| panic!("Cannot get access to a Dom when one is not in progress."))
+            .clone()
+    })
 }
 
 /// Binds a DOM on the current thread.
@@ -34,27 +39,6 @@ pub fn bind_dom(dom: &Dom) {
 /// Panics if there is no DOM currently being updated on this thread.
 pub fn unbind_dom() {
     unbind(&CURRENT_DOM);
-}
-
-/// Borrow a thread local storage and allow it to be held for 'static.
-fn borrow<T>(storage: &'static LocalKey<Storage<T>>) -> Ref<'static, T> {
-    storage.with(|context| {
-        // SAFETY: Rust won't give us a 'static reference here because this
-        // thread could send the 'static value to another thread and then die
-        // prematurely. This would be bad.
-        //
-        // However, we have some good news! Ref<T> is not Send and never will
-        // be. We can rest assured that this reference will never outlive the
-        // thread it originated from.
-        let context = unsafe { extend_lifetime(context) };
-
-        let context = context.borrow();
-        Ref::map(context, |context| {
-            context.as_ref().unwrap_or_else(|| {
-                panic!("Cannot get access to a Dom when one is not in progress.")
-            })
-        })
-    })
 }
 
 fn bind<T>(storage: &'static LocalKey<Storage<T>>, value: T) {
@@ -74,8 +58,4 @@ fn unbind<T>(storage: &'static LocalKey<Storage<T>>) {
             panic!("Cannot stop a Dom when there is not one in progress.");
         });
     });
-}
-
-unsafe fn extend_lifetime<'a, T>(value: &'a T) -> &'static T {
-    std::mem::transmute::<&'a T, &'static T>(value)
 }


### PR DESCRIPTION
Here is a potential approach to fix #211

Since `Dom` is already a wrapper over `Rc`, a clone can be returned from `context::dom` instead of having to extend the `Ref` lifetime.

Are there any issues with this approach?