### PR TITLE
Fix SDL text input not being stopped

### DIFF
--- a/crates/yakui-sdl3/src/lib.rs
+++ b/crates/yakui-sdl3/src/lib.rs
@@ -48,6 +48,8 @@ impl YakuiSdl3 {
             },
             (true, true) | (false, false) => {}
         }
+
+        self.text_input_enabled = new_value;
     }
 
     pub fn handle_event(&mut self, state: &mut yakui_core::Yakui, event: &SdlEvent) -> bool {


### PR DESCRIPTION
The SDL backend stores the last seen state of a text input being enabled, but didn't update it, which caused it to not tell SDL it was done with text input.
