### PR TITLE
Add directional navigation and revamp focus

### DIFF
--- a/crates/yakui-core/src/event.rs
+++ b/crates/yakui-core/src/event.rs
@@ -138,9 +138,6 @@ bitflags::bitflags! {
         /// Notify this widget whenever the mouse cursor moves.
         const MOUSE_MOVE = 4;
 
-        /// This widget can be focused.
-        const FOCUS = 8;
-
         /// If this widget is focused, it should receive keyboard events.
         const FOCUSED_KEYBOARD = 16;
 

--- a/crates/yakui-core/src/input/input_state.rs
+++ b/crates/yakui-core/src/input/input_state.rs
@@ -9,7 +9,7 @@ use crate::event::{Event, EventInterest, EventResponse, WidgetEvent};
 use crate::id::WidgetId;
 use crate::layout::LayoutDom;
 use crate::navigation::{navigate, NavDirection};
-use crate::widget::EventContext;
+use crate::widget::{EventContext, FocusPolicy};
 
 use super::mouse::MouseButton;
 use super::{KeyCode, Modifiers};
@@ -35,6 +35,9 @@ pub struct InputState {
 
     /// If there's a pending navigation event, it's stored here!
     pending_navigation: Cell<Option<NavDirection>>,
+
+    /// If set, navigation is enabled.
+    navigation_enabled: Cell<bool>,
 
     /// If set, text input should be active.
     text_input_enabled: Cell<bool>,
@@ -120,6 +123,7 @@ impl InputState {
             last_focus: Cell::new(None),
             pending_navigation: Cell::new(None),
             text_input_enabled: Cell::new(false),
+            navigation_enabled: Cell::new(true),
         }
     }
 
@@ -171,6 +175,11 @@ impl InputState {
     /// Set the currently focused widget.
     pub fn set_focus(&self, id: Option<WidgetId>) {
         self.focus.set(id);
+    }
+
+    /// Sets whether navigation is enabled.
+    pub fn set_navigation_enabled(&self, enabled: bool) {
+        self.navigation_enabled.set(enabled);
     }
 
     /// Attempt to navigate in a direction within the UI.
@@ -309,29 +318,78 @@ impl InputState {
         down: bool,
         modifiers: Option<Modifiers>,
     ) -> EventResponse {
-        let focus = self.focus.get();
-        if let Some(id) = focus {
-            let Some(layout_node) = layout.get(id) else {
-                return EventResponse::Bubble;
-            };
+        let modifiers = modifiers.unwrap_or(self.modifiers.get());
+        let res = self.send_key_to_focus(dom, layout, key, down, modifiers);
+        if res == EventResponse::Sink {
+            // don't attempt key navigation
+            return res;
+        }
+        self.key_navigate(key, down, modifiers)
+    }
 
-            if layout_node
-                .event_interest
-                .contains(EventInterest::FOCUSED_KEYBOARD)
-            {
-                // Panic safety: if this node is in the layout DOM, it must be
-                // in the DOM.
-                let mut node = dom.get_mut(id).unwrap();
-                let event = WidgetEvent::KeyChanged {
-                    key,
-                    down,
-                    modifiers: modifiers.unwrap_or(self.modifiers.get()),
-                };
-                return self.fire_event(dom, layout, id, &mut node, &event);
-            }
+    fn send_key_to_focus(
+        &self,
+        dom: &Dom,
+        layout: &LayoutDom,
+        key: KeyCode,
+        down: bool,
+        modifiers: Modifiers,
+    ) -> EventResponse {
+        let Some(id) = self.focus.get() else {
+            return EventResponse::Bubble;
+        };
+        let Some(layout_node) = layout.get(id) else {
+            return EventResponse::Bubble;
+        };
+
+        if !layout_node
+            .event_interest
+            .contains(EventInterest::FOCUSED_KEYBOARD)
+        {
+            return EventResponse::Bubble;
         }
 
-        EventResponse::Bubble
+        // Panic safety: if this node is in the layout DOM, it must be
+        // in the DOM.
+        let mut node = dom.get_mut(id).unwrap();
+        let event = WidgetEvent::KeyChanged {
+            key,
+            down,
+            modifiers,
+        };
+        self.fire_event(dom, layout, id, &mut node, &event)
+    }
+
+    fn key_navigate(&self, key: KeyCode, down: bool, modifiers: Modifiers) -> EventResponse {
+        if !self.navigation_enabled.get() {
+            return EventResponse::Bubble;
+        }
+
+        let direction = match key {
+            KeyCode::Tab if modifiers.shift() => NavDirection::Previous,
+            KeyCode::Tab => NavDirection::Next,
+            KeyCode::ArrowDown => NavDirection::Down,
+            KeyCode::ArrowUp => NavDirection::Up,
+            KeyCode::ArrowLeft => NavDirection::Left,
+            KeyCode::ArrowRight => NavDirection::Right,
+            _ => return EventResponse::Bubble,
+        };
+
+        if self.focus().is_none()
+            && matches!(
+                direction,
+                NavDirection::Down | NavDirection::Up | NavDirection::Left | NavDirection::Right
+            )
+        {
+            return EventResponse::Bubble;
+        }
+
+        if down {
+            self.navigate(direction);
+        }
+
+        // still sink the up too
+        EventResponse::Sink
     }
 
     fn modifiers_changed(&self, modifiers: &Modifiers) -> EventResponse {
@@ -382,6 +440,17 @@ impl InputState {
                     modifiers: self.modifiers.get(),
                 };
                 let response = self.fire_event(dom, layout, id, &mut node, &event);
+                drop(node);
+
+                if button == MouseButton::One
+                    && down
+                    && response == EventResponse::Sink
+                    && self.focus().is_none()
+                {
+                    if let Some(target) = pointer_focus_target(dom, id) {
+                        self.focus.set(Some(target));
+                    }
+                }
 
                 if response == EventResponse::Sink {
                     overall_response = response;
@@ -561,5 +630,15 @@ fn hit_test(_dom: &Dom, layout: &LayoutDom, coords: Vec2, output: &mut Vec<Widge
         if rect.contains_point(coords) {
             output.push(id);
         }
+    }
+}
+
+fn pointer_focus_target(dom: &Dom, mut current: WidgetId) -> Option<WidgetId> {
+    loop {
+        let node = dom.get(current)?;
+        if node.widget.focus_policy().contains(FocusPolicy::POINTER) {
+            return Some(current);
+        }
+        current = node.parent?;
     }
 }

--- a/crates/yakui-core/src/input/input_state.rs
+++ b/crates/yakui-core/src/input/input_state.rs
@@ -14,7 +14,7 @@ use crate::widget::EventContext;
 use super::mouse::MouseButton;
 use super::{KeyCode, Modifiers};
 
-/// Holds yakui's input state, like cursor position, hovered, and selected
+/// Holds yakui's input state, like cursor position, hovered, and focused
 /// widgets.
 #[derive(Debug)]
 pub struct InputState {
@@ -27,11 +27,11 @@ pub struct InputState {
     /// Details about widgets and their mouse intersections.
     intersections: RefCell<Intersections>,
 
-    /// The widget that is currently selected.
-    selection: Cell<Option<WidgetId>>,
+    /// The widget that is currently focused.
+    focus: Cell<Option<WidgetId>>,
 
-    /// The widget that was selected last frame.
-    last_selection: Cell<Option<WidgetId>>,
+    /// The widget that was focused last frame.
+    last_focus: Cell<Option<WidgetId>>,
 
     /// If there's a pending navigation event, it's stored here!
     pending_navigation: Cell<Option<NavDirection>>,
@@ -116,8 +116,8 @@ impl InputState {
                 mouse_entered_and_sunk: Vec::new(),
                 mouse_down_in: HashMap::new(),
             }),
-            selection: Cell::new(None),
-            last_selection: Cell::new(None),
+            focus: Cell::new(None),
+            last_focus: Cell::new(None),
             pending_navigation: Cell::new(None),
             text_input_enabled: Cell::new(false),
         }
@@ -126,7 +126,7 @@ impl InputState {
     /// Begin a new frame for input handling.
     pub fn start(&self, dom: &Dom, layout: &LayoutDom) {
         self.text_input_enabled.set(false);
-        self.notify_selection(dom, layout);
+        self.notify_focus(dom, layout);
     }
 
     /// Finish applying input events for this frame.
@@ -138,7 +138,7 @@ impl InputState {
     fn handle_navigation(&self, dom: &Dom, layout: &LayoutDom) {
         if let Some(dir) = self.pending_navigation.take() {
             if let Some(new_focus) = navigate(dom, layout, self, dir) {
-                self.set_selection(Some(new_focus));
+                self.set_focus(Some(new_focus));
             }
         }
     }
@@ -163,14 +163,14 @@ impl InputState {
             .map(|pos| pos / layout.scale_factor())
     }
 
-    /// Return the currently selected widget, if there is one.
-    pub fn selection(&self) -> Option<WidgetId> {
-        self.selection.get()
+    /// Return the currently focused widget, if there is one.
+    pub fn focus(&self) -> Option<WidgetId> {
+        self.focus.get()
     }
 
-    /// Set the currently selected widget.
-    pub fn set_selection(&self, id: Option<WidgetId>) {
-        self.selection.set(id);
+    /// Set the currently focused widget.
+    pub fn set_focus(&self, id: Option<WidgetId>) {
+        self.focus.set(id);
     }
 
     /// Attempt to navigate in a direction within the UI.
@@ -190,10 +190,10 @@ impl InputState {
                 EventResponse::Bubble
             }
             Event::MouseButtonChanged { button, down } => {
-                // Left clicking clears selection, unless the widget handling the event sets the
-                // same selection again
+                // Left clicking clears focus, unless the widget handling the event sets the
+                // same focus again
                 if button == &MouseButton::One && *down {
-                    self.selection.set(None);
+                    self.focus.set(None);
                 }
                 self.mouse_button_changed(dom, layout, *button, *down)
             }
@@ -206,21 +206,21 @@ impl InputState {
             Event::ModifiersChanged(modifiers) => self.modifiers_changed(modifiers),
             Event::TextInput(c) => self.text_input(dom, layout, *c),
             Event::RequestFocus(id) => {
-                self.set_selection(*id);
+                self.set_focus(*id);
                 EventResponse::Bubble
             }
             _ => EventResponse::Bubble,
         };
 
-        // Any input events can change selection, notify of changes immediately
-        self.notify_selection(dom, layout);
+        // Any input events can change focus, notify of changes immediately
+        self.notify_focus(dom, layout);
 
         res
     }
 
-    fn notify_selection(&self, dom: &Dom, layout: &LayoutDom) {
-        let mut current = self.selection.get();
-        let last = self.last_selection.get();
+    fn notify_focus(&self, dom: &Dom, layout: &LayoutDom) {
+        let mut current = self.focus.get();
+        let last = self.last_focus.get();
 
         if current == last {
             return;
@@ -236,7 +236,7 @@ impl InputState {
                     &WidgetEvent::FocusChanged(true),
                 );
             } else {
-                self.selection.set(None);
+                self.focus.set(None);
                 current = None;
             }
         }
@@ -253,7 +253,7 @@ impl InputState {
             }
         }
 
-        self.last_selection.set(current);
+        self.last_focus.set(current);
     }
 
     /// Signal that the mouse has moved.
@@ -309,8 +309,8 @@ impl InputState {
         down: bool,
         modifiers: Option<Modifiers>,
     ) -> EventResponse {
-        let selected = self.selection.get();
-        if let Some(id) = selected {
+        let focus = self.focus.get();
+        if let Some(id) = focus {
             let Some(layout_node) = layout.get(id) else {
                 return EventResponse::Bubble;
             };
@@ -340,8 +340,8 @@ impl InputState {
     }
 
     fn text_input(&self, dom: &Dom, layout: &LayoutDom, c: char) -> EventResponse {
-        let selected = self.selection.get();
-        if let Some(id) = selected {
+        let focus = self.focus.get();
+        if let Some(id) = focus {
             let Some(layout_node) = layout.get(id) else {
                 return EventResponse::Bubble;
             };

--- a/crates/yakui-core/src/navigation.rs
+++ b/crates/yakui-core/src/navigation.rs
@@ -24,17 +24,36 @@ pub enum NavDirection {
     Right,
 }
 
+impl NavDirection {
+    /// Returns the corresponding [`NavDirections`] flag.
+    pub const fn flag(self) -> NavDirections {
+        match self {
+            NavDirection::Next => NavDirections::NEXT,
+            NavDirection::Previous => NavDirections::PREVIOUS,
+            NavDirection::Down => NavDirections::DOWN,
+            NavDirection::Up => NavDirections::UP,
+            NavDirection::Left => NavDirections::LEFT,
+            NavDirection::Right => NavDirections::RIGHT,
+        }
+    }
+}
+
 pub(crate) fn navigate(
     dom: &Dom,
     layout: &LayoutDom,
     input: &InputState,
     dir: NavDirection,
 ) -> Option<WidgetId> {
+    let ctx = NavigateContext { dom, layout, input };
     let mut current = input.focus();
 
+    // allow sequential navigation from the root if nothing is focused
+    if current.is_none() && matches!(dir, NavDirection::Next | NavDirection::Previous) {
+        return ctx.try_navigate(dom.root(), dir);
+    }
+
     while let Some(id) = current {
-        let node = dom.get(id).unwrap();
-        let ctx = NavigateContext { dom, layout, input };
+        let node = dom.get(id)?;
 
         if let Some(new_id) = ctx.try_navigate(id, dir) {
             return Some(new_id);
@@ -44,4 +63,34 @@ pub(crate) fn navigate(
     }
 
     None
+}
+
+bitflags::bitflags! {
+    /// A bitfield of navigation directions.
+    #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy, Default)]
+    pub struct NavDirections: u8 {
+        /// Next
+        const NEXT = 1 << 0;
+        /// Previous
+        const PREVIOUS = 1 << 1;
+        /// Down
+        const DOWN = 1 << 2;
+        /// Up
+        const UP = 1 << 3;
+        /// Left
+        const LEFT = 1 << 4;
+        /// Right
+        const RIGHT = 1 << 5;
+
+        /// Sequential
+        const SEQUENTIAL = Self::NEXT.bits() | Self::PREVIOUS.bits();
+        /// Vertical
+        const VERTICAL = Self::UP.bits() | Self::DOWN.bits();
+        /// Horizontal
+        const HORIZONTAL = Self::LEFT.bits() | Self::RIGHT.bits();
+        /// Directional
+        const DIRECTIONAL = Self::VERTICAL.bits() | Self::HORIZONTAL.bits();
+        /// All directions
+        const ALL = Self::SEQUENTIAL.bits() | Self::DIRECTIONAL.bits();
+    }
 }

--- a/crates/yakui-core/src/navigation.rs
+++ b/crates/yakui-core/src/navigation.rs
@@ -30,7 +30,7 @@ pub(crate) fn navigate(
     input: &InputState,
     dir: NavDirection,
 ) -> Option<WidgetId> {
-    let mut current = input.selection();
+    let mut current = input.focus();
 
     while let Some(id) = current {
         let node = dom.get(id).unwrap();

--- a/crates/yakui-core/src/widget.rs
+++ b/crates/yakui-core/src/widget.rs
@@ -9,7 +9,7 @@ use glam::Vec2;
 use crate::dom::Dom;
 use crate::event::EventResponse;
 use crate::event::{EventInterest, WidgetEvent};
-use crate::geometry::{Constraints, FlexFit};
+use crate::geometry::{Constraints, FlexFit, Rect};
 use crate::input::InputState;
 use crate::layout::LayoutDom;
 use crate::navigation::NavDirection;
@@ -39,6 +39,32 @@ impl LayoutContext<'_> {
     pub fn calculate_layout(&mut self, widget: WidgetId, constraints: Constraints) -> Vec2 {
         self.layout
             .calculate(self.dom, self.input, self.paint, widget, constraints)
+    }
+
+    /// Returns the current layout rectangle for the given widget relative
+    /// to the given ancestor.
+    pub fn rect_relative_to(&self, widget: WidgetId, ancestor: WidgetId) -> Option<Rect> {
+        let layout = self.layout.get(widget)?;
+        let mut rect = layout.rect;
+
+        if widget == ancestor {
+            rect.set_pos(Vec2::ZERO);
+            return Some(rect);
+        }
+
+        let mut current = widget;
+
+        loop {
+            let parent = self.dom.get(current)?.parent?;
+            if parent == ancestor {
+                return Some(rect);
+            }
+
+            let parent_layout = self.layout.get(parent)?;
+            rect.set_pos(rect.pos() + parent_layout.rect.pos());
+
+            current = parent;
+        }
     }
 }
 
@@ -112,6 +138,67 @@ impl NavigateContext<'_> {
         }
 
         false
+    }
+
+    fn nearest_in_direction(
+        &self,
+        origin: WidgetId,
+        dir: NavDirection,
+        candidates: impl IntoIterator<Item = WidgetId>,
+    ) -> Option<WidgetId> {
+        candidates
+            .into_iter()
+            .filter_map(|candidate| {
+                self.directional_score(origin, candidate, dir)
+                    .map(|score| (candidate, score))
+            })
+            .min_by(|(_, score_a), (_, score_b)| score_a.total_cmp(score_b))
+            .map(|(candidate, _)| candidate)
+    }
+
+    /// Returns the directional desirebility of a candidate widget
+    /// as a score where lower is better
+    fn directional_score(
+        &self,
+        origin: WidgetId,
+        candidate: WidgetId,
+        dir: NavDirection,
+    ) -> Option<f32> {
+        let origin = self.layout.get(origin)?.rect.center();
+        let candidate = self.layout.get(candidate)?.rect.center();
+        let delta = candidate - origin;
+
+        let (forward, cross) = match dir {
+            NavDirection::Down => (delta.y, delta.x),
+            NavDirection::Up => (-delta.y, delta.x),
+            NavDirection::Left => (-delta.x, delta.y),
+            NavDirection::Right => (delta.x, delta.y),
+            NavDirection::Next | NavDirection::Previous => return None,
+        };
+
+        if forward <= 0.0 {
+            return None;
+        }
+
+        // Prefer parallel widgets
+        let score = forward * forward + 2.0 * cross * cross;
+        score.is_finite().then_some(score)
+    }
+}
+
+bitflags::bitflags! {
+    /// A bitfield representing the focus policy of a widget.
+    #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy, Default)]
+    pub struct FocusPolicy: u8 {
+        /// Focusable through sequential navigation.
+        const SEQUENTIAL = 1 << 0;
+
+        /// Focusable through directional navigation.
+        const DIRECTIONAL = 1 << 1;
+
+        /// Automatically focused when this widget or one of its
+        /// descendants sinks a primary pointer click.
+        const POINTER = 1 << 2;
     }
 }
 
@@ -208,18 +295,29 @@ pub trait Widget: 'static + fmt::Debug {
         EventResponse::Bubble
     }
 
+    /// Returns the focus policy for this widget.
+    ///
+    /// The default implementation implies no focus behavior.
+    fn focus_policy(&self) -> FocusPolicy {
+        FocusPolicy::empty()
+    }
+
     /// Tell which widget should be navigated to if the user navigates in a
     /// given direction.
-    #[allow(unused)]
     fn navigate(&self, ctx: NavigateContext<'_>, dir: NavDirection) -> Option<WidgetId> {
+        self.default_navigate(ctx, dir)
+    }
+
+    /// Perform the default navigation based on focus and position.
+    fn default_navigate(&self, ctx: NavigateContext<'_>, dir: NavDirection) -> Option<WidgetId> {
         let node_id = ctx.dom.current();
         let node = ctx.dom.get_current();
 
-        let focus = ctx.input.focus()?;
+        let focus = ctx.input.focus();
         let mut current_index = None;
 
         for (index, &child) in node.children.iter().enumerate() {
-            if ctx.contains(child, focus) {
+            if focus.is_some_and(|focus| ctx.contains(child, focus)) {
                 current_index = Some(index);
                 break;
             }
@@ -249,8 +347,19 @@ pub trait Widget: 'static + fmt::Debug {
                     }
                 }
 
-                _ => {
-                    log::debug!("NavDirection::{dir:?} not implemented in Widget::navigate.");
+                NavDirection::Down
+                | NavDirection::Up
+                | NavDirection::Left
+                | NavDirection::Right => {
+                    let focus = focus?;
+
+                    let candidates = node
+                        .children
+                        .iter()
+                        .enumerate()
+                        .filter(|(child_index, _)| *child_index != index)
+                        .filter_map(|(_, &child)| ctx.try_navigate(child, dir));
+                    return ctx.nearest_in_direction(focus, dir, candidates);
                 }
             }
 
@@ -260,9 +369,22 @@ pub trait Widget: 'static + fmt::Debug {
             // should pick the widget that's nearest to the given navigation
             // direction that's focusable.
 
-            if focus != node_id && self.event_interest().contains(EventInterest::FOCUS) {
-                // This widget is directly focusable, so focus it!
-                return Some(node_id);
+            if focus != Some(node_id) {
+                let policy = self.focus_policy();
+
+                let can_focus = match dir {
+                    NavDirection::Next | NavDirection::Previous => {
+                        policy.contains(FocusPolicy::SEQUENTIAL)
+                    }
+                    NavDirection::Down
+                    | NavDirection::Up
+                    | NavDirection::Left
+                    | NavDirection::Right => policy.contains(FocusPolicy::DIRECTIONAL),
+                };
+
+                if can_focus {
+                    return Some(node_id);
+                }
             }
 
             match dir {
@@ -286,9 +408,17 @@ pub trait Widget: 'static + fmt::Debug {
                     None
                 }
 
-                _ => {
-                    log::debug!("NavDirection::{dir:?} not implemented in Widget::navigate.");
-                    None
+                NavDirection::Down
+                | NavDirection::Up
+                | NavDirection::Left
+                | NavDirection::Right => {
+                    let focus = focus?;
+
+                    let candidates = node
+                        .children
+                        .iter()
+                        .filter_map(|&child| ctx.try_navigate(child, dir));
+                    ctx.nearest_in_direction(focus, dir, candidates)
                 }
             }
         }
@@ -317,6 +447,9 @@ pub trait ErasedWidget: Any + fmt::Debug {
 
     /// Returns the type name of the widget, usable only for debugging.
     fn type_name(&self) -> &'static str;
+
+    /// See [`Widget::focus_policy`].
+    fn focus_policy(&self) -> FocusPolicy;
 
     /// See [`Widget::navigate`].
     fn navigate(&self, ctx: NavigateContext<'_>, dir: NavDirection) -> Option<WidgetId>;
@@ -354,6 +487,10 @@ where
 
     fn type_name(&self) -> &'static str {
         type_name::<T>()
+    }
+
+    fn focus_policy(&self) -> FocusPolicy {
+        <T as Widget>::focus_policy(self)
     }
 
     fn navigate(&self, ctx: NavigateContext<'_>, dir: NavDirection) -> Option<WidgetId> {

--- a/crates/yakui-core/src/widget.rs
+++ b/crates/yakui-core/src/widget.rs
@@ -215,11 +215,11 @@ pub trait Widget: 'static + fmt::Debug {
         let node_id = ctx.dom.current();
         let node = ctx.dom.get_current();
 
-        let selection = ctx.input.selection()?;
+        let focus = ctx.input.focus()?;
         let mut current_index = None;
 
         for (index, &child) in node.children.iter().enumerate() {
-            if ctx.contains(child, selection) {
+            if ctx.contains(child, focus) {
                 current_index = Some(index);
                 break;
             }
@@ -260,7 +260,7 @@ pub trait Widget: 'static + fmt::Debug {
             // should pick the widget that's nearest to the given navigation
             // direction that's focusable.
 
-            if selection != node_id && self.event_interest().contains(EventInterest::FOCUS) {
+            if focus != node_id && self.event_interest().contains(EventInterest::FOCUS) {
                 // This widget is directly focusable, so focus it!
                 return Some(node_id);
             }

--- a/crates/yakui-core/tests/regression.rs
+++ b/crates/yakui-core/tests/regression.rs
@@ -69,7 +69,7 @@ impl Widget for KeyboardWidget {
     }
 
     fn layout(&self, ctx: LayoutContext<'_>, _constraints: Constraints) -> Vec2 {
-        ctx.input.set_selection(Some(ctx.dom.current()));
+        ctx.input.set_focus(Some(ctx.dom.current()));
         Vec2::ZERO
     }
 

--- a/crates/yakui-widgets/src/shorthand.rs
+++ b/crates/yakui-widgets/src/shorthand.rs
@@ -6,6 +6,7 @@
 use std::borrow::Cow;
 
 use yakui_core::geometry::{Color, Constraints, Dim2, Vec2};
+use yakui_core::navigation::NavDirections;
 use yakui_core::widget::PaintContext;
 use yakui_core::{Alignment, ManagedTextureId, Pivot, Response, TextureId};
 
@@ -16,7 +17,7 @@ use crate::widgets::{
     Flexible, FlexibleResponse, Image, ImageResponse, List, ListResponse, MaxWidth,
     MaxWidthResponse, NineSlice, Offset, OffsetResponse, Opaque, OpaqueResponse, Pad, PadResponse,
     Reflow, ReflowResponse, Scrollable, ScrollableResponse, Slider, SliderResponse, Spacer, Stack,
-    StackResponse, State, StateResponse, Text, TextBox, TextBoxResponse, TextResponse,
+    StackResponse, State, StateResponse, Text, TextBox, TextBoxResponse, TextResponse, Trap,
 };
 
 /// See [List].
@@ -223,6 +224,12 @@ pub fn max_width(max_width: f32, children: impl FnOnce()) -> Response<MaxWidthRe
 #[track_caller]
 pub fn stack(children: impl FnOnce()) -> Response<StackResponse> {
     Stack::new().show(children)
+}
+
+/// See [Trap].
+#[track_caller]
+pub fn trap(children: impl FnOnce()) -> Response<()> {
+    Trap::new(NavDirections::ALL).show(children)
 }
 
 #[track_caller]

--- a/crates/yakui-widgets/src/widgets/button.rs
+++ b/crates/yakui-widgets/src/widgets/button.rs
@@ -2,8 +2,8 @@ use std::borrow::Cow;
 
 use yakui_core::event::{EventInterest, EventResponse, WidgetEvent};
 use yakui_core::geometry::Color;
-use yakui_core::input::MouseButton;
-use yakui_core::widget::{EventContext, Widget};
+use yakui_core::input::{KeyCode, MouseButton};
+use yakui_core::widget::{EventContext, FocusPolicy, Widget};
 use yakui_core::{Alignment, Response};
 
 use crate::border::{Border, BorderRadius};
@@ -37,6 +37,7 @@ pub struct Button {
     pub style: DynamicButtonStyle,
     pub hover_style: DynamicButtonStyle,
     pub down_style: DynamicButtonStyle,
+    pub focus_style: DynamicButtonStyle,
 }
 
 auto_builders!(Button {
@@ -47,6 +48,7 @@ auto_builders!(Button {
     style: DynamicButtonStyle,
     hover_style: DynamicButtonStyle,
     down_style: DynamicButtonStyle,
+    focus_style: DynamicButtonStyle,
 });
 
 /// Contains styles that can vary based on the state of the button.
@@ -83,6 +85,7 @@ impl Button {
             style: DynamicButtonStyle::default(),
             hover_style: DynamicButtonStyle::default(),
             down_style: DynamicButtonStyle::default(),
+            focus_style: DynamicButtonStyle::default(),
         }
     }
 
@@ -107,6 +110,12 @@ impl Button {
             ..Default::default()
         };
 
+        let focus_style = DynamicButtonStyle {
+            fill: style.fill,
+            border: down_style.border,
+            ..Default::default()
+        };
+
         Self {
             text: text.into(),
             alignment: Alignment::CENTER,
@@ -115,6 +124,7 @@ impl Button {
             style,
             hover_style,
             down_style,
+            focus_style,
         }
     }
 
@@ -130,12 +140,14 @@ pub struct ButtonWidget {
     hovering: bool,
     mouse_down: bool,
     clicked: bool,
+    focused: bool,
 }
 
 #[derive(Debug)]
 pub struct ButtonResponse {
     pub hovering: bool,
     pub clicked: bool,
+    pub focused: bool,
 }
 
 impl Widget for ButtonWidget {
@@ -148,6 +160,7 @@ impl Widget for ButtonWidget {
             hovering: false,
             mouse_down: false,
             clicked: false,
+            focused: false,
         }
     }
 
@@ -165,6 +178,11 @@ impl Widget for ButtonWidget {
             border = style.border;
         } else if self.hovering {
             let style = &self.props.hover_style;
+            color = style.fill;
+            text_style = style.text.clone();
+            border = style.border;
+        } else if self.focused {
+            let style = &self.props.focus_style;
             color = style.fill;
             text_style = style.text.clone();
             border = style.border;
@@ -193,11 +211,16 @@ impl Widget for ButtonWidget {
         Self::Response {
             hovering: self.hovering,
             clicked,
+            focused: self.focused,
         }
     }
 
+    fn focus_policy(&self) -> FocusPolicy {
+        FocusPolicy::SEQUENTIAL | FocusPolicy::DIRECTIONAL | FocusPolicy::POINTER
+    }
+
     fn event_interest(&self) -> EventInterest {
-        EventInterest::MOUSE_INSIDE | EventInterest::MOUSE_OUTSIDE
+        EventInterest::MOUSE_INSIDE | EventInterest::MOUSE_OUTSIDE | EventInterest::FOCUSED_KEYBOARD
     }
 
     fn event(&mut self, _ctx: EventContext<'_>, event: &WidgetEvent) -> EventResponse {
@@ -234,6 +257,20 @@ impl Widget for ButtonWidget {
 
                     EventResponse::Bubble
                 }
+            }
+            WidgetEvent::FocusChanged(focused) => {
+                self.focused = *focused;
+                EventResponse::Bubble
+            }
+            WidgetEvent::KeyChanged {
+                key: KeyCode::Enter | KeyCode::NumpadEnter,
+                down,
+                ..
+            } => {
+                if *down {
+                    self.clicked = true;
+                }
+                EventResponse::Sink
             }
             _ => EventResponse::Bubble,
         }

--- a/crates/yakui-widgets/src/widgets/checkbox.rs
+++ b/crates/yakui-widgets/src/widgets/checkbox.rs
@@ -1,9 +1,10 @@
 use yakui_core::event::{EventInterest, EventResponse, WidgetEvent};
-use yakui_core::geometry::{Constraints, Vec2};
-use yakui_core::input::MouseButton;
-use yakui_core::widget::{EventContext, LayoutContext, PaintContext, Widget};
+use yakui_core::geometry::{Color, Constraints, Vec2};
+use yakui_core::input::{KeyCode, MouseButton};
+use yakui_core::widget::{EventContext, FocusPolicy, LayoutContext, PaintContext, Widget};
 use yakui_core::Response;
 
+use crate::border::Border;
 use crate::shapes::RoundedRectangle;
 use crate::{colors, shapes};
 
@@ -46,11 +47,13 @@ pub struct CheckboxWidget {
     hovering: bool,
     mouse_down: bool,
     just_toggled: bool,
+    focused: bool,
 }
 
 #[derive(Debug)]
 pub struct CheckboxResponse {
     pub checked: bool,
+    pub focused: bool,
 }
 
 impl Widget for CheckboxWidget {
@@ -63,6 +66,7 @@ impl Widget for CheckboxWidget {
             hovering: false,
             mouse_down: false,
             just_toggled: false,
+            focused: false,
         }
     }
 
@@ -75,7 +79,10 @@ impl Widget for CheckboxWidget {
             self.just_toggled = false;
         }
 
-        CheckboxResponse { checked }
+        CheckboxResponse {
+            checked,
+            focused: self.focused,
+        }
     }
 
     fn paint(&self, ctx: PaintContext<'_>) {
@@ -86,7 +93,24 @@ impl Widget for CheckboxWidget {
         check_rect.set_pos(check_rect.pos() + padding / 2.0);
         check_rect.set_size(check_rect.size() - padding);
 
-        let bg = RoundedRectangle::new(layout_node.rect, 6.0).color(colors::BACKGROUND_3);
+        let (background, border) = if self.mouse_down {
+            (
+                colors::BACKGROUND_3.adjust(0.8),
+                Border::new(Color::WHITE, 1.0),
+            )
+        } else if self.hovering {
+            (
+                colors::BACKGROUND_3.adjust(1.2),
+                Border::new(Color::WHITE.adjust(0.75), 1.0),
+            )
+        } else if self.focused {
+            (colors::BACKGROUND_3, Border::new(Color::WHITE, 1.0))
+        } else {
+            (colors::BACKGROUND_3, Border::new(colors::BACKGROUND_1, 1.0))
+        };
+        let bg = RoundedRectangle::new(layout_node.rect, 6.0)
+            .color(background)
+            .border(Some(border));
         bg.add(ctx.paint);
 
         if self.props.checked {
@@ -98,8 +122,12 @@ impl Widget for CheckboxWidget {
         constraints.constrain_min(Vec2::splat(OUTER_SIZE))
     }
 
+    fn focus_policy(&self) -> FocusPolicy {
+        FocusPolicy::SEQUENTIAL | FocusPolicy::DIRECTIONAL | FocusPolicy::POINTER
+    }
+
     fn event_interest(&self) -> EventInterest {
-        EventInterest::MOUSE_INSIDE | EventInterest::MOUSE_OUTSIDE
+        EventInterest::MOUSE_INSIDE | EventInterest::MOUSE_OUTSIDE | EventInterest::FOCUSED_KEYBOARD
     }
 
     fn event(&mut self, _ctx: EventContext<'_>, event: &WidgetEvent) -> EventResponse {
@@ -133,6 +161,20 @@ impl Widget for CheckboxWidget {
                     self.mouse_down = false;
                     EventResponse::Bubble
                 }
+            }
+            WidgetEvent::FocusChanged(focused) => {
+                self.focused = *focused;
+                EventResponse::Bubble
+            }
+            WidgetEvent::KeyChanged {
+                key: KeyCode::Enter | KeyCode::NumpadEnter,
+                down,
+                ..
+            } => {
+                if *down {
+                    self.just_toggled = true;
+                }
+                EventResponse::Sink
             }
             _ => EventResponse::Bubble,
         }

--- a/crates/yakui-widgets/src/widgets/mod.rs
+++ b/crates/yakui-widgets/src/widgets/mod.rs
@@ -30,6 +30,7 @@ mod stack;
 mod state;
 mod text;
 mod textbox;
+mod trap;
 mod unconstrained_box;
 mod window;
 
@@ -65,5 +66,6 @@ pub use self::stack::*;
 pub use self::state::*;
 pub use self::text::*;
 pub use self::textbox::*;
+pub use self::trap::*;
 pub use self::unconstrained_box::*;
 pub use self::window::*;

--- a/crates/yakui-widgets/src/widgets/scrollable.rs
+++ b/crates/yakui-widgets/src/widgets/scrollable.rs
@@ -3,7 +3,7 @@ use std::cell::Cell;
 use yakui_core::event::{EventInterest, EventResponse, WidgetEvent};
 use yakui_core::geometry::{Constraints, Vec2};
 use yakui_core::widget::{EventContext, LayoutContext, PaintContext, Widget};
-use yakui_core::Response;
+use yakui_core::{Response, WidgetId};
 
 use crate::util::widget_children;
 
@@ -35,11 +35,26 @@ pub enum ScrollDirection {
     Y,
 }
 
+impl ScrollDirection {
+    fn axis(self, vec: Vec2) -> f32 {
+        match self {
+            ScrollDirection::Y => vec.y,
+        }
+    }
+
+    fn axis_mut(self, vec: &mut Vec2) -> &mut f32 {
+        match self {
+            ScrollDirection::Y => &mut vec.y,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct ScrollableWidget {
     props: Scrollable,
     scroll_position: Cell<Vec2>,
     canvas_size: Cell<Vec2>,
+    last_focus: Cell<Option<WidgetId>>,
 }
 
 pub type ScrollableResponse = ();
@@ -53,6 +68,7 @@ impl Widget for ScrollableWidget {
             props: Scrollable::none(),
             scroll_position: Cell::new(Vec2::ZERO),
             canvas_size: Cell::new(Vec2::ZERO),
+            last_focus: Cell::new(None),
         }
     }
 
@@ -81,6 +97,7 @@ impl Widget for ScrollableWidget {
         self.canvas_size.set(canvas_size);
 
         let size = constraints.constrain(canvas_size);
+        self.scroll_to_focus(&ctx, size);
 
         let max_scroll_position = (canvas_size - size).max(Vec2::ZERO);
         let mut scroll_position = self
@@ -124,5 +141,43 @@ impl Widget for ScrollableWidget {
             }
             _ => EventResponse::Bubble,
         }
+    }
+}
+
+impl ScrollableWidget {
+    fn scroll_to_focus(&self, ctx: &LayoutContext<'_>, viewport_size: Vec2) {
+        let Some(dir) = self.props.direction else {
+            return;
+        };
+
+        let focus = ctx.input.focus();
+        if self.last_focus.replace(focus) == focus {
+            return;
+        }
+        let Some(focus) = focus else {
+            return;
+        };
+        let scrollable = ctx.dom.current();
+        let Some(focused_rect) = ctx.rect_relative_to(focus, scrollable) else {
+            return;
+        };
+
+        let mut scroll_position = self.scroll_position.get();
+
+        let current_scroll = dir.axis(scroll_position);
+        let viewport_end = dir.axis(viewport_size);
+
+        let visible_start = dir.axis(focused_rect.pos()) - current_scroll;
+        let visible_end = dir.axis(focused_rect.max()) - current_scroll;
+
+        if visible_start < 0.0 {
+            // before the viewport
+            *dir.axis_mut(&mut scroll_position) += visible_start;
+        } else if visible_end > viewport_end {
+            // after the viewport
+            *dir.axis_mut(&mut scroll_position) += visible_end - viewport_end;
+        }
+
+        self.scroll_position.set(scroll_position);
     }
 }

--- a/crates/yakui-widgets/src/widgets/slider.rs
+++ b/crates/yakui-widgets/src/widgets/slider.rs
@@ -1,7 +1,9 @@
 use std::cell::Cell;
 
+use yakui_core::event::{EventInterest, EventResponse, WidgetEvent};
 use yakui_core::geometry::{Color, Constraints, Rect, Vec2};
-use yakui_core::widget::{LayoutContext, PaintContext, Widget};
+use yakui_core::input::KeyCode;
+use yakui_core::widget::{EventContext, FocusPolicy, LayoutContext, PaintContext, Widget};
 use yakui_core::Response;
 
 use crate::{auto_builders, colored_circle, colors, draggable, util};
@@ -52,6 +54,7 @@ impl Slider {
 pub struct SliderResponse {
     pub confirmed: bool,
     pub value: Option<f64>,
+    pub focused: bool,
 }
 
 #[derive(Debug)]
@@ -59,6 +62,30 @@ pub struct SliderWidget {
     props: Slider,
     rect: Cell<Option<Rect>>,
     dragging: bool,
+    pending_value: Option<f64>,
+    confirmed: bool,
+    focused: bool,
+}
+
+impl SliderWidget {
+    fn current_value(&self) -> f64 {
+        self.pending_value.unwrap_or(self.props.value)
+    }
+
+    fn keyboard_step(&self) -> f64 {
+        self.props
+            .step
+            // 1% if no step configured
+            .unwrap_or((self.props.max - self.props.min) / 100.0)
+            .abs()
+    }
+
+    fn clamp_value(&self, value: f64) -> f64 {
+        value.clamp(
+            self.props.min.min(self.props.max),
+            self.props.min.max(self.props.max),
+        )
+    }
 }
 
 impl Widget for SliderWidget {
@@ -70,6 +97,9 @@ impl Widget for SliderWidget {
             props: Slider::new(0.0, 0.0, 1.0),
             rect: Cell::new(None),
             dragging: false,
+            pending_value: None,
+            confirmed: false,
+            focused: false,
         }
     }
 
@@ -81,7 +111,8 @@ impl Widget for SliderWidget {
             colored_circle(KNOB_COLOR, KNOB_SIZE);
         });
 
-        let confirmed = self.dragging && res.dragging.is_none();
+        let confirmed = (self.dragging && res.dragging.is_none()) || self.confirmed;
+        self.confirmed = false;
         self.dragging = res.dragging.is_some();
 
         let mut value = self.props.value;
@@ -95,19 +126,26 @@ impl Widget for SliderWidget {
             value = self.props.min + percentage as f64 * (self.props.max - self.props.min);
         }
 
+        if let Some(pending_value) = self.pending_value.take() {
+            value = pending_value;
+        }
+
         if let Some(step) = self.props.step {
             value = round_to_step(value, step);
         }
+        value = self.clamp_value(value);
 
         if value != self.props.value {
             SliderResponse {
                 value: Some(value),
                 confirmed,
+                focused: self.focused,
             }
         } else {
             SliderResponse {
                 value: None,
                 confirmed,
+                focused: self.focused,
             }
         }
     }
@@ -137,6 +175,40 @@ impl Widget for SliderWidget {
         ctx.layout.set_pos(knob, knob_pos);
 
         size
+    }
+
+    fn focus_policy(&self) -> FocusPolicy {
+        FocusPolicy::SEQUENTIAL | FocusPolicy::DIRECTIONAL | FocusPolicy::POINTER
+    }
+
+    fn event_interest(&self) -> EventInterest {
+        EventInterest::FOCUSED_KEYBOARD
+    }
+
+    fn event(&mut self, _ctx: EventContext<'_>, event: &WidgetEvent) -> EventResponse {
+        match event {
+            WidgetEvent::FocusChanged(focused) => {
+                self.focused = *focused;
+                EventResponse::Bubble
+            }
+            WidgetEvent::KeyChanged { key, down, .. } => {
+                let value = match key {
+                    KeyCode::ArrowLeft => self.current_value() - self.keyboard_step(),
+                    KeyCode::ArrowRight => self.current_value() + self.keyboard_step(),
+                    KeyCode::Home => self.props.min,
+                    KeyCode::End => self.props.max,
+                    _ => return EventResponse::Bubble,
+                };
+
+                if *down {
+                    self.pending_value = Some(self.clamp_value(value));
+                    self.confirmed = true;
+                }
+
+                EventResponse::Sink
+            }
+            _ => EventResponse::Bubble,
+        }
     }
 
     fn paint(&self, mut ctx: PaintContext<'_>) {

--- a/crates/yakui-widgets/src/widgets/textbox.rs
+++ b/crates/yakui-widgets/src/widgets/textbox.rs
@@ -461,7 +461,7 @@ impl Widget for TextBoxWidget {
                     });
                 }
 
-                ctx.input.set_selection(Some(ctx.dom.current()));
+                ctx.input.set_focus(Some(ctx.dom.current()));
 
                 EventResponse::Sink
             }
@@ -681,7 +681,7 @@ impl Widget for TextBoxWidget {
                                             self.text_changed_by_cosmic.set(true);
                                         } else {
                                             self.activated = true;
-                                            ctx.input.set_selection(None);
+                                            ctx.input.set_focus(None);
                                         }
                                     } else {
                                         editor.action(font_system, cosmic_text::Action::Enter);
@@ -696,7 +696,7 @@ impl Widget for TextBoxWidget {
                                 if *down {
                                     editor.action(font_system, cosmic_text::Action::Escape);
                                     if self.props.inline_edit {
-                                        ctx.input.set_selection(None);
+                                        ctx.input.set_focus(None);
                                     }
                                 }
                                 res = EventResponse::Sink;

--- a/crates/yakui-widgets/src/widgets/textbox.rs
+++ b/crates/yakui-widgets/src/widgets/textbox.rs
@@ -5,9 +5,8 @@ use cosmic_text::{Edit, Selection};
 use yakui_core::event::{EventInterest, EventResponse, WidgetEvent};
 use yakui_core::geometry::{Color, Constraints, Rect, Vec2};
 use yakui_core::input::{KeyCode, Modifiers, MouseButton};
-use yakui_core::navigation::NavDirection;
 use yakui_core::paint::PaintRect;
-use yakui_core::widget::{EventContext, LayoutContext, PaintContext, Widget};
+use yakui_core::widget::{EventContext, FocusPolicy, LayoutContext, PaintContext, Widget};
 use yakui_core::Response;
 
 use crate::clipboard::ClipboardHolder;
@@ -358,11 +357,12 @@ impl Widget for TextBoxWidget {
         self.default_paint(ctx);
     }
 
+    fn focus_policy(&self) -> FocusPolicy {
+        FocusPolicy::SEQUENTIAL | FocusPolicy::DIRECTIONAL | FocusPolicy::POINTER
+    }
+
     fn event_interest(&self) -> EventInterest {
-        EventInterest::MOUSE_INSIDE
-            | EventInterest::FOCUS
-            | EventInterest::FOCUSED_KEYBOARD
-            | EventInterest::MOUSE_MOVE
+        EventInterest::MOUSE_INSIDE | EventInterest::FOCUSED_KEYBOARD | EventInterest::MOUSE_MOVE
     }
 
     fn event(&mut self, ctx: EventContext<'_>, event: &WidgetEvent) -> EventResponse {
@@ -461,8 +461,6 @@ impl Widget for TextBoxWidget {
                     });
                 }
 
-                ctx.input.set_focus(Some(ctx.dom.current()));
-
                 EventResponse::Sink
             }
 
@@ -489,16 +487,12 @@ impl Widget for TextBoxWidget {
                         let res;
 
                         match key {
+                            // Allow navigation when appropriate
                             KeyCode::Tab => {
-                                if *down {
-                                    if modifiers.shift() {
-                                        ctx.input.navigate(NavDirection::Previous);
-                                    } else {
-                                        ctx.input.navigate(NavDirection::Next);
-                                    }
-                                }
-
-                                res = EventResponse::Sink;
+                                res = EventResponse::Bubble;
+                            }
+                            KeyCode::ArrowUp | KeyCode::ArrowDown if !self.props.multiline => {
+                                res = EventResponse::Bubble
                             }
 
                             KeyCode::ArrowLeft => {

--- a/crates/yakui-widgets/src/widgets/trap.rs
+++ b/crates/yakui-widgets/src/widgets/trap.rs
@@ -1,0 +1,66 @@
+use yakui_core::{
+    navigation::{NavDirection, NavDirections},
+    widget::{NavigateContext, Widget},
+    Response, WidgetId,
+};
+
+use crate::util::widget_children;
+
+/**
+A widget that traps navigation within its descendants.
+*/
+#[derive(Debug, Clone, Copy)]
+#[must_use = "yakui widgets do nothing if you don't `show` them"]
+pub struct Trap {
+    pub directions: NavDirections,
+}
+
+impl Trap {
+    pub const fn new(directions: NavDirections) -> Self {
+        Self { directions }
+    }
+
+    #[track_caller]
+    pub fn show(self, children: impl FnOnce()) -> Response<()> {
+        widget_children::<TrapWidget, _>(children, self)
+    }
+}
+
+#[derive(Debug)]
+pub struct TrapWidget {
+    props: Trap,
+}
+
+impl Widget for TrapWidget {
+    type Props<'a> = Trap;
+    type Response = ();
+
+    fn new() -> Self {
+        Self {
+            props: Trap::new(NavDirections::ALL),
+        }
+    }
+
+    fn update(&mut self, props: Self::Props<'_>) -> Self::Response {
+        self.props = props;
+    }
+
+    fn navigate(&self, ctx: NavigateContext<'_>, direction: NavDirection) -> Option<WidgetId> {
+        // first, navigate among descendants normally
+        if let Some(target) = self.default_navigate(ctx, direction) {
+            return Some(target);
+        }
+
+        let focus = ctx.input.focus()?;
+
+        // if the focus originated inside, keep it there
+        if self.props.directions.contains(direction.flag())
+            && ctx.contains(ctx.dom.current(), focus)
+        {
+            return Some(focus);
+        }
+
+        // it originated outside
+        None
+    }
+}

--- a/crates/yakui/examples/navigation.rs
+++ b/crates/yakui/examples/navigation.rs
@@ -1,0 +1,103 @@
+use bootstrap::ExampleState;
+use yakui::colors::BACKGROUND_2;
+use yakui::navigation::NavDirections;
+use yakui::widgets::{List, Pad, Slider, TextBox, Trap};
+use yakui::{
+    button, checkbox, colored_box_container, label, pad, scroll_vertical, use_state,
+    MainAxisAlignment, MainAxisSize,
+};
+
+pub fn run(_state: &mut ExampleState) {
+    pad(Pad::all(20.0), || {
+        List::column()
+            .item_spacing(8.0_f32)
+            .main_axis_size(MainAxisSize::Min)
+            .show(|| {
+                label("Start by clicking, or using sequential navigation");
+
+                section("Directional grid", || {
+                    List::column().item_spacing(8.0_f32).show(|| {
+                        for row in 0..3 {
+                            List::row().item_spacing(8.0_f32).show(|| {
+                                for column in 0..3 {
+                                    let index = row * 3 + column + 1;
+                                    button(format!("Button {index}"));
+                                }
+                            });
+                        }
+                    });
+                });
+
+                section(
+                    "Widgets, like the text box and slider, might consume navigation keys",
+                    || {
+                        let checked = use_state(|| false);
+                        let checkbox_res = checkbox(checked.get());
+                        checked.set(checkbox_res.checked);
+
+                        let text = use_state(|| String::from("Edit me"));
+                        let textbox_res = TextBox::new(text.borrow().clone())
+                            .placeholder("Type here")
+                            .show();
+                        if let Some(new_text) = textbox_res.into_inner().text {
+                            text.set(new_text);
+                        }
+
+                        let slider_value = use_state(|| 50.0);
+                        let slider_res =
+                            Slider::new(slider_value.get(), 0.0, 100.0).step(5.0).show();
+                        if let Some(value) = slider_res.value {
+                            slider_value.set(value);
+                        }
+                        label(format!("Slider value: {:.0}", slider_value.get()));
+                    },
+                );
+
+                Trap::new(NavDirections::DIRECTIONAL).show(|| {
+                    section(
+                        "Directional trap! Arrow navigation stays inside this row.",
+                        || {
+                            button("You're trapped! 1");
+                            button("You're trapped! 2");
+                            button("You're trapped! 3");
+                        },
+                    );
+                });
+
+                section("Scrollable focus", || {
+                    scroll_vertical(|| {
+                        List::column().item_spacing(4.0_f32).show(|| {
+                            for index in 1..=12 {
+                                button(format!("Scrollable button {index}"));
+                            }
+                        });
+                    });
+                });
+            });
+    });
+}
+
+fn section(title: &'static str, children: impl FnOnce()) {
+    List::column()
+        .main_axis_size(MainAxisSize::Min)
+        .item_spacing(4.0_f32)
+        .show(|| {
+            label(title);
+
+            colored_box_container(BACKGROUND_2, || {
+                Pad::all(8.0).show(|| {
+                    List::row()
+                        .main_axis_size(MainAxisSize::Min)
+                        .main_axis_alignment(MainAxisAlignment::Center)
+                        .item_spacing(8.0_f32)
+                        .show(|| {
+                            children();
+                        });
+                });
+            });
+        });
+}
+
+fn main() {
+    bootstrap::start(run as fn(&mut ExampleState));
+}


### PR DESCRIPTION
Revamps the focus system with support for focus by sequential and now directional navigation, as well as pointer focus [^1].

Also adds a new "trap" component that prevents navigation from escaping outside its descendants, directions are configurable.

Focus is no longer an event interest, because it doesn't really make sense for event interests to affect navigation, which happens whether the widget cares about it or not.

Sequential navigation can now occur without anything focused, which feels normal. Also, I added an API to disable keyboard navigation, which users might consider utilizing in like, locked camera modes where it is unexpected.

I also renamed selection to focus, as they were the same thing.

Widgets were updated to handle and surface focus state.

Things it's missing that I still want but can wait:
- A generic way to unfocus  whatever is focused, with the keyboard, i.e. pressing escape. We should handle this the same way we handle navigation and pointer unfocusing by making sure the event wasn't sunk by a widget first
- Related, a way to know if a descendant widget is focused.
  - This is useful for styling of certain elements: imagine a row with a button next to some text. We might be literally focused on the button, but we may want the row to be highlighted
  - This is also useful for modals so that they can close when they have no descendants with focus without extra logic
    - MS80: now blur could handle this and we could remove the escape-to-close in various places colocated with blur
- A way to focus a widget in the `Widget::update()` context.
  - new slider!

[^1]: This wasn't really necessary but I just noticed repetition in widgets all needing to handle focusing themselves when clicked. Still unsure. If you *are* a fan of this, we may consider (later) making "hover" and "click/activate" more abstract concepts too, because the vast majority of widgets handle these states identically and it just ends up being very repetitive. We can always let users override this behavior, and this makes spinning up new interactive widgets faster.